### PR TITLE
Fix for clones of private repositories

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,8 +16,11 @@ pytest = "*"
 pyfakefs = "*"
 pytest-cov = "*"
 wheel = "*"
-continuous-delivery-scripts = {editable = true, path = "."}
+continuous-delivery-scripts = {path = "."}
 pre-commit = "*"
 
 [pipenv]
 allow_prereleases = true
+
+[packages]
+continuous-delivery-scripts = {path = "."}

--- a/continuous_delivery_scripts/__init__.py
+++ b/continuous_delivery_scripts/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Scripts and utilities used by the CI pipeline."""

--- a/continuous_delivery_scripts/_version.py
+++ b/continuous_delivery_scripts/_version.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """The version number is based on semantic versioning.

--- a/continuous_delivery_scripts/assert_news.py
+++ b/continuous_delivery_scripts/assert_news.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Checks if valid news files are created for changes in the project."""

--- a/continuous_delivery_scripts/create_news_file.py
+++ b/continuous_delivery_scripts/create_news_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Easy news files generation.

--- a/continuous_delivery_scripts/generate_docs.py
+++ b/continuous_delivery_scripts/generate_docs.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Generates documentation."""

--- a/continuous_delivery_scripts/generate_news.py
+++ b/continuous_delivery_scripts/generate_news.py
@@ -57,7 +57,7 @@ def _calculate_version(commit_type: CommitType, use_news_files: bool) -> Tuple[b
     new_version: Optional[str] = None
     is_new_version: bool = False
     with cd(os.path.dirname(project_config_path)):
-        old, _, updates = auto_version_tool.main(
+        old, new_version, updates = auto_version_tool.main(
             release=is_release,
             enable_file_triggers=enable_file_triggers,
             commit_count_as=bump,
@@ -66,7 +66,9 @@ def _calculate_version(commit_type: CommitType, use_news_files: bool) -> Tuple[b
         # Autoversion second returned value is not actually the new version
         # There seem to be a bug in autoversion.
         # This is why the following needs to be done to determine the version
-        new_version = updates["__version__"]
+        for k, v in updates.items():
+            if "version" in str(k).lower():
+                new_version = updates[k]
         is_new_version = old != new_version
     logger.info(":: Determining the new version")
     logger.info(f"Version: {new_version}")

--- a/continuous_delivery_scripts/generate_news.py
+++ b/continuous_delivery_scripts/generate_news.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Handles usage of towncrier for automated changelog generation and pyautoversion for versioning."""

--- a/continuous_delivery_scripts/get_config.py
+++ b/continuous_delivery_scripts/get_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Retrieves configuration values."""

--- a/continuous_delivery_scripts/language_specifics.py
+++ b/continuous_delivery_scripts/language_specifics.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Language plugins Loader."""

--- a/continuous_delivery_scripts/license_files.py
+++ b/continuous_delivery_scripts/license_files.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Apply copyright and licensing to all source files present in a project.

--- a/continuous_delivery_scripts/plugins/__init__.py
+++ b/continuous_delivery_scripts/plugins/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Language specific actions."""

--- a/continuous_delivery_scripts/plugins/docker.py
+++ b/continuous_delivery_scripts/plugins/docker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for Docker projects."""

--- a/continuous_delivery_scripts/plugins/golang.py
+++ b/continuous_delivery_scripts/plugins/golang.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for Golang projects."""

--- a/continuous_delivery_scripts/plugins/noop.py
+++ b/continuous_delivery_scripts/plugins/noop.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """No Operation plugin."""

--- a/continuous_delivery_scripts/plugins/python.py
+++ b/continuous_delivery_scripts/plugins/python.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for Python projects."""

--- a/continuous_delivery_scripts/report_third_party_ip.py
+++ b/continuous_delivery_scripts/report_third_party_ip.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Script providing information about licensing and third party IP in order to comply with OpenChain.

--- a/continuous_delivery_scripts/spdx_report/__init__.py
+++ b/continuous_delivery_scripts/spdx_report/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Module in charge of handling SPDX documents.

--- a/continuous_delivery_scripts/spdx_report/spdx_dependency.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_dependency.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of dependency SPDX Document."""

--- a/continuous_delivery_scripts/spdx_report/spdx_document.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_document.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX Document."""

--- a/continuous_delivery_scripts/spdx_report/spdx_file.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX File."""

--- a/continuous_delivery_scripts/spdx_report/spdx_helpers.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Facilities regarding SPDX.

--- a/continuous_delivery_scripts/spdx_report/spdx_package.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_package.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX Package."""

--- a/continuous_delivery_scripts/spdx_report/spdx_project.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX report for a Python project."""

--- a/continuous_delivery_scripts/spdx_report/spdx_summary.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_summary.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Summary generators."""

--- a/continuous_delivery_scripts/tag_and_release.py
+++ b/continuous_delivery_scripts/tag_and_release.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Orchestrates release process."""

--- a/continuous_delivery_scripts/utils/__init__.py
+++ b/continuous_delivery_scripts/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility scripts to abstract and assist with scripts run in the CI."""

--- a/continuous_delivery_scripts/utils/aws_helpers.py
+++ b/continuous_delivery_scripts/utils/aws_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for interacting with AWS services such as S3.

--- a/continuous_delivery_scripts/utils/configuration.py
+++ b/continuous_delivery_scripts/utils/configuration.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities in charge of fetching configuration values for the ci scripts."""

--- a/continuous_delivery_scripts/utils/definitions.py
+++ b/continuous_delivery_scripts/utils/definitions.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Place to store generic project concepts for the ci scripts."""

--- a/continuous_delivery_scripts/utils/filesystem_helpers.py
+++ b/continuous_delivery_scripts/utils/filesystem_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers with regards to actions on the filesystem."""

--- a/continuous_delivery_scripts/utils/git_helpers.py
+++ b/continuous_delivery_scripts/utils/git_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility script to abstract git operations for our CI scripts."""
@@ -48,8 +48,7 @@ class GitWrapper:
         path = url.split("github.com", 1)[1][1:].strip()
         new = "https://{GITHUB_TOKEN}:x-oauth-basic@github.com/%s" % path
         logger.info("rewriting git url to: %s" % new)
-        return new.format(GITHUB_TOKEN=configuration.get_value(
-            ConfigurationVariable.GIT_TOKEN))
+        return new.format(GITHUB_TOKEN=configuration.get_value(ConfigurationVariable.GIT_TOKEN))
 
     def clone(self, path: Path) -> "GitWrapper":
         """Clones this repository to the path.
@@ -62,8 +61,7 @@ class GitWrapper:
         """
         try:
             git_clone = self.repo.clone_from(
-                url=self.get_remote_url(), to_path=str(path),
-                multi_options=["--recurse-submodules"]
+                url=self.get_remote_url(), to_path=str(path), multi_options=["--recurse-submodules"]
             )
         except GitCommandError as e:
             logger.info("failed cloning repository: %s" % e)
@@ -71,7 +69,7 @@ class GitWrapper:
             git_clone = self.repo.clone_from(
                 url=self._git_url_ssh_to_https(self.get_remote_url()),
                 to_path=str(path),
-                multi_options=["--recurse-submodules"]
+                multi_options=["--recurse-submodules"],
             )
 
         clone = GitWrapper(path=path, repo=git_clone)
@@ -90,10 +88,8 @@ class GitWrapper:
 
     def configure_author(self) -> None:
         """Sets the author."""
-        self.repo.config_writer().set_value("user", "name",
-                                            self.author.name).release()
-        self.repo.config_writer().set_value("user", "email",
-                                            self.author.email).release()
+        self.repo.config_writer().set_value("user", "name", self.author.name).release()
+        self.repo.config_writer().set_value("user", "email", self.author.email).release()
 
     def checkout_branch(self, branch_name: str) -> Any:
         """Checks out a branch from its name.
@@ -128,8 +124,7 @@ class GitWrapper:
         if not path_model.is_absolute():
             path_model = Path(self.root).joinpath(path_model)
         if not path_model.exists():
-            logger.warning(
-                f"[Git] {path_model} cannot be added because not found.")
+            logger.warning(f"[Git] {path_model} cannot be added because not found.")
             return
         relative_path = str(path_model.relative_to(self.root))
         unix_relative_path = relative_path.replace("\\", "/")
@@ -150,8 +145,7 @@ class GitWrapper:
         else:
             self._add_one_file_or_one_dir(path)
 
-    def commit(self, message: str,
-               **kwargs: Optional[Tuple[str, Any]]) -> None:
+    def commit(self, message: str, **kwargs: Optional[Tuple[str, Any]]) -> None:
         """Commits changes to the repository.
 
         Args:
@@ -167,8 +161,7 @@ class GitWrapper:
         Returns:
             corresponding branch
         """
-        return self.get_branch(
-            configuration.get_value(ConfigurationVariable.MASTER_BRANCH))
+        return self.get_branch(configuration.get_value(ConfigurationVariable.MASTER_BRANCH))
 
     def get_beta_branch(self) -> Any:
         """Gets the `beta` branch.
@@ -176,8 +169,7 @@ class GitWrapper:
         Returns:
             corresponding branch
         """
-        return self.get_branch(
-            configuration.get_value(ConfigurationVariable.BETA_BRANCH))
+        return self.get_branch(configuration.get_value(ConfigurationVariable.BETA_BRANCH))
 
     def is_release_branch(self, branch_name: Optional[str]) -> bool:
         """Checks whether the branch is a `release` branch or not.
@@ -188,8 +180,7 @@ class GitWrapper:
         Returns:
             True if the branch is used for `release` code; False otherwise
         """
-        branch_pattern = configuration.get_value(
-            ConfigurationVariable.RELEASE_BRANCH_PATTERN)
+        branch_pattern = configuration.get_value(ConfigurationVariable.RELEASE_BRANCH_PATTERN)
         if not branch_pattern or not branch_name:
             return False
         is_release: Optional[Any] = re.search(branch_pattern, str(branch_name))
@@ -232,8 +223,7 @@ class GitWrapper:
         try:
             return self.repo.active_branch
         except TypeError as e:
-            logger.warning(
-                f"Could not determine the branch name using GitPython: {e}")
+            logger.warning(f"Could not determine the branch name using GitPython: {e}")
         current_branch = self._get_branch_from_advanced_feature()
         if not current_branch:
             current_branch = self._get_branch_from_abbreviation("HEAD")
@@ -242,17 +232,13 @@ class GitWrapper:
     def _get_branch_from_advanced_feature(self) -> Any:
         if version.parse(self.git_version()) >= version.parse("2.22"):
             current_branch = self.repo.git.branch(show_current=True)
-            current_branch = current_branch if isinstance(current_branch,
-                                                          str) else current_branch.decode(
-                "utf-8")
+            current_branch = current_branch if isinstance(current_branch, str) else current_branch.decode("utf-8")
             return self.get_branch(current_branch)
         return None
 
     def _get_branch_from_abbreviation(self, abbreviation: str) -> Any:
         current_branch = self.repo.git.rev_parse("--abbrev-ref", abbreviation)
-        current_branch = current_branch if isinstance(current_branch,
-                                                      str) else current_branch.decode(
-            "utf-8")
+        current_branch = current_branch if isinstance(current_branch, str) else current_branch.decode("utf-8")
         return self.get_branch(current_branch.strip())
 
     def get_commit_count(self) -> int:
@@ -306,8 +292,7 @@ class GitWrapper:
         current_branch = self.get_current_branch()
         merge_base = self.repo.merge_base(branch, current_branch)
         self.repo.index.merge_tree(current_branch, base=merge_base)
-        self.commit(f"Merge from {str(branch)}",
-                    parent_commits=(branch.commit, current_branch.commit))
+        self.commit(f"Merge from {str(branch)}", parent_commits=(branch.commit, current_branch.commit))
 
     def get_remote_url(self) -> str:
         """Gets the URL of the remote repository.
@@ -340,9 +325,7 @@ class GitWrapper:
         remote = self._get_remote()
         if remote:
             self.repo.delete_remote(str(remote))
-        self.repo.create_remote(
-            configuration.get_value(ConfigurationVariable.REMOTE_ALIAS),
-            url=url)
+        self.repo.create_remote(configuration.get_value(ConfigurationVariable.REMOTE_ALIAS), url=url)
 
     def get_remote_branch(self, branch_name: str) -> Optional[Any]:
         """Gets the branch present in the remote repository.
@@ -369,8 +352,7 @@ class GitWrapper:
             branch_name: name of the remote branch.
         """
         if self.remote_branch_exists(branch_name):
-            self.repo.git.branch("--set-upstream-to",
-                                 self.get_remote_branch(branch_name))
+            self.repo.git.branch("--set-upstream-to", self.get_remote_branch(branch_name))
 
     def delete_branch(self, branch: Any) -> None:
         """Deletes a branch.
@@ -412,21 +394,17 @@ class GitWrapper:
         """
         return self.get_remote_branch(branch_name) is not None
 
-    def _get_specific_changes(self, change_type: Optional[str], commit1: Any,
-                              commit2: Any) -> List[str]:
+    def _get_specific_changes(self, change_type: Optional[str], commit1: Any, commit2: Any) -> List[str]:
         diff = commit1.diff(commit2)
         if change_type:
             change_type = change_type.upper()
             change_type = change_type if change_type in diff.change_type else None
-        diff_iterator = diff.iter_change_type(
-            change_type) if change_type else diff
-        changes = [change.a_path if change.a_path else change.b_path for change
-                   in diff_iterator]
+        diff_iterator = diff.iter_change_type(change_type) if change_type else diff
+        changes = [change.a_path if change.a_path else change.b_path for change in diff_iterator]
         return changes
 
     def get_changes_list(
-            self, commit1: Any, commit2: Any,
-            change_type: Optional[str] = None, dir: Optional[str] = None
+        self, commit1: Any, commit2: Any, change_type: Optional[str] = None, dir: Optional[str] = None
     ) -> List[str]:
         """Gets change list.
 
@@ -446,8 +424,7 @@ class GitWrapper:
         if dir:
             windows_path = dir.replace("/", "\\")
             linux_path = dir.replace("\\", "/")
-            return [change for change in changes if
-                    (linux_path in change) or (windows_path in change)]
+            return [change for change in changes if (linux_path in change) or (windows_path in change)]
         else:
             return changes
 
@@ -458,13 +435,11 @@ class GitWrapper:
     def pull(self) -> None:
         """Pulls changes on current branch from the remote repository."""
         if self.remote_branch_exists(self.get_current_branch()):
-            self.repo.git.pull(self._get_remote(), self.get_current_branch(),
-                               quiet=True)
+            self.repo.git.pull(self._get_remote(), self.get_current_branch(), quiet=True)
 
     def force_pull(self) -> None:
         """Force pulls changes from the remote repository."""
-        self.repo.git.pull(self._get_remote(), self.get_current_branch(),
-                           quiet=True, force=True)
+        self.repo.git.pull(self._get_remote(), self.get_current_branch(), quiet=True, force=True)
 
     def push(self) -> None:
         """Pushes commits.
@@ -472,8 +447,7 @@ class GitWrapper:
         Pushes changes to the remote repository.
         Pushes also relevant annotated tags when pushing branches out.
         """
-        self.repo.git.push("--follow-tags", "--set-upstream",
-                           self._get_remote(), self.get_current_branch())
+        self.repo.git.push("--follow-tags", "--set-upstream", self._get_remote(), self.get_current_branch())
 
     def push_tag(self) -> None:
         """Pushes commits and tags.
@@ -536,25 +510,21 @@ class GitWrapper:
         Returns:
             the version of git in use.
         """
-        return ".".join(
-            [str(element) for element in self.repo.git.version_info])
+        return ".".join([str(element) for element in self.repo.git.version_info])
 
     def _get_remote(self) -> Optional[Any]:
         try:
-            return self.repo.remote(
-                configuration.get_value(ConfigurationVariable.REMOTE_ALIAS))
+            return self.repo.remote(configuration.get_value(ConfigurationVariable.REMOTE_ALIAS))
         except (IndexError, ValueError) as e:
             logger.warning(e)
             return None
 
     def list_files_added_on_current_branch(self) -> List[str]:
         """Returns a list of files changed against master branch."""
-        master_branch_commit = self.repo.commit(
-            configuration.get_value(ConfigurationVariable.MASTER_BRANCH))
+        master_branch_commit = self.repo.commit(configuration.get_value(ConfigurationVariable.MASTER_BRANCH))
         current_branch_commit = self.repo.commit(self.get_current_branch())
         changes = self.get_changes_list(
-            self.get_branch_point(master_branch_commit, current_branch_commit),
-            current_branch_commit, change_type="a"
+            self.get_branch_point(master_branch_commit, current_branch_commit), current_branch_commit, change_type="a"
         )
         return changes
 
@@ -577,8 +547,7 @@ class GitWrapper:
         if not status:
             return []
 
-        return [Path(self.root).joinpath(line.strip().split(" ")[-1]) for line
-                in status.splitlines()]
+        return [Path(self.root).joinpath(line.strip().split(" ")[-1]) for line in status.splitlines()]
 
     @staticmethod
     def _apply_modifications(destination: Path, modified_file: Path) -> None:
@@ -614,10 +583,8 @@ class ProjectGitWrapper(GitWrapper):
     def __init__(self) -> None:
         """Creates a Git Wrapper."""
         super().__init__(
-            path=Path(
-                configuration.get_value(ConfigurationVariable.PROJECT_ROOT)),
-            repo=Repo(
-                configuration.get_value(ConfigurationVariable.PROJECT_ROOT)),
+            path=Path(configuration.get_value(ConfigurationVariable.PROJECT_ROOT)),
+            repo=Repo(configuration.get_value(ConfigurationVariable.PROJECT_ROOT)),
         )
 
 
@@ -658,8 +625,7 @@ class GitClone(GitWrapper):
     @staticmethod
     def wrap(repo: GitWrapper, initial_location: Path) -> "GitClone":
         """Wraps around around a repository."""
-        return GitClone(repo=repo.repo, path=repo.root,
-                        initial_path=initial_location)
+        return GitClone(repo=repo.repo, path=repo.root, initial_path=initial_location)
 
     @property
     def initial_location(self) -> Path:
@@ -682,8 +648,7 @@ class GitClone(GitWrapper):
             return Path(self.root).joinpath(path_in_initial_repo)
         try:
             # Tyring to find if the path corresponds to a file/directory present in intial repository
-            return Path(self.root).joinpath(
-                path_in_initial_repo.relative_to(self.initial_location))
+            return Path(self.root).joinpath(path_in_initial_repo.relative_to(self.initial_location))
         except ValueError:
             return path_in_initial_repo
 
@@ -691,8 +656,7 @@ class GitClone(GitWrapper):
 class GitTempClone:
     """Context manager providing a temporary cloned repository."""
 
-    def __init__(self, desired_branch_name: Optional[str],
-                 repository_to_clone: GitWrapper):
+    def __init__(self, desired_branch_name: Optional[str], repository_to_clone: GitWrapper):
         """Constructor.
 
         Args:
@@ -700,13 +664,10 @@ class GitTempClone:
             repository_to_clone: the repository to clone. If not specified, the project repository will be used.
         """
         self._temporary_dir = TemporaryDirectory()
-        logger.info(
-            f"Creating a temporary repository in {self._temporary_dir}")
+        logger.info(f"Creating a temporary repository in {self._temporary_dir}")
         self._repo = repository_to_clone
-        _current_branch_name = desired_branch_name if desired_branch_name else str(
-            self._repo.get_current_branch())
-        self._clone = GitClone.wrap(self._repo.clone(self._temporary_dir.path),
-                                    initial_location=self._repo.root)
+        _current_branch_name = desired_branch_name if desired_branch_name else str(self._repo.get_current_branch())
+        self._clone = GitClone.wrap(self._repo.clone(self._temporary_dir.path), initial_location=self._repo.root)
         self._clone.checkout(_current_branch_name)
         self._repo.apply_uncommitted_changes(self._clone)
 
@@ -737,5 +698,4 @@ class ProjectTempClone(GitTempClone):
             system will try to identify the current branch in the repository which
             will work in most cases but probably not on CI.
         """
-        super().__init__(desired_branch_name=desired_branch_name,
-                         repository_to_clone=ProjectGitWrapper())
+        super().__init__(desired_branch_name=desired_branch_name, repository_to_clone=ProjectGitWrapper())

--- a/continuous_delivery_scripts/utils/hash_helpers.py
+++ b/continuous_delivery_scripts/utils/hash_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for calculating hashes or UUID."""

--- a/continuous_delivery_scripts/utils/language_specifics_base.py
+++ b/continuous_delivery_scripts/utils/language_specifics_base.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Base class for all Language plugins."""

--- a/continuous_delivery_scripts/utils/logging.py
+++ b/continuous_delivery_scripts/utils/logging.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for logging errors according to severity of the exception."""

--- a/continuous_delivery_scripts/utils/noop/__init__.py
+++ b/continuous_delivery_scripts/utils/noop/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility scripts specific to noop."""

--- a/continuous_delivery_scripts/utils/noop/package_helpers.py
+++ b/continuous_delivery_scripts/utils/noop/package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities for retrieving NoOp's package information."""

--- a/continuous_delivery_scripts/utils/package_helpers.py
+++ b/continuous_delivery_scripts/utils/package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities for retrieving Python's package information."""

--- a/continuous_delivery_scripts/utils/python/__init__.py
+++ b/continuous_delivery_scripts/utils/python/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility scripts specific to python."""

--- a/continuous_delivery_scripts/utils/python/package_helpers.py
+++ b/continuous_delivery_scripts/utils/python/package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities for retrieving Python's package information."""

--- a/continuous_delivery_scripts/utils/python/python_helpers.py
+++ b/continuous_delivery_scripts/utils/python/python_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities around python language."""

--- a/continuous_delivery_scripts/utils/string_helpers.py
+++ b/continuous_delivery_scripts/utils/string_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities regarding string handling."""

--- a/continuous_delivery_scripts/utils/third_party_licences.py
+++ b/continuous_delivery_scripts/utils/third_party_licences.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Third party licences."""

--- a/docs/assert_news.html
+++ b/docs/assert_news.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/create_news_file.html
+++ b/docs/create_news_file.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/generate_docs.html
+++ b/docs/generate_docs.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/generate_news.html
+++ b/docs/generate_news.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/get_config.html
+++ b/docs/get_config.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/language_specifics.html
+++ b/docs/language_specifics.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/license_files.html
+++ b/docs/license_files.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/docker.html
+++ b/docs/plugins/docker.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/golang.html
+++ b/docs/plugins/golang.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/index.html
+++ b/docs/plugins/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/noop.html
+++ b/docs/plugins/noop.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/python.html
+++ b/docs/plugins/python.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/report_third_party_ip.html
+++ b/docs/report_third_party_ip.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/index.html
+++ b/docs/spdx_report/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_dependency.html
+++ b/docs/spdx_report/spdx_dependency.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_document.html
+++ b/docs/spdx_report/spdx_document.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_file.html
+++ b/docs/spdx_report/spdx_file.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_helpers.html
+++ b/docs/spdx_report/spdx_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_package.html
+++ b/docs/spdx_report/spdx_package.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_project.html
+++ b/docs/spdx_report/spdx_project.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_summary.html
+++ b/docs/spdx_report/spdx_summary.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/tag_and_release.html
+++ b/docs/tag_and_release.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/third_party_IP_report.html
+++ b/docs/third_party_IP_report.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/aws_helpers.html
+++ b/docs/utils/aws_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/configuration.html
+++ b/docs/utils/configuration.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/definitions.html
+++ b/docs/utils/definitions.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/filesystem_helpers.html
+++ b/docs/utils/filesystem_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/git_helpers.html
+++ b/docs/utils/git_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/hash_helpers.html
+++ b/docs/utils/hash_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/index.html
+++ b/docs/utils/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/language_specifics_base.html
+++ b/docs/utils/language_specifics_base.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/logging.html
+++ b/docs/utils/logging.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/noop/index.html
+++ b/docs/utils/noop/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/noop/package_helpers.html
+++ b/docs/utils/noop/package_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/package_helpers.html
+++ b/docs/utils/package_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/python/index.html
+++ b/docs/utils/python/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/python/package_helpers.html
+++ b/docs/utils/python/package_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/python/python_helpers.html
+++ b/docs/utils/python/python_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/string_helpers.html
+++ b/docs/utils/string_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/third_party_licences.html
+++ b/docs/utils/third_party_licences.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm. All rights reserved.
+-- Copyright (C) 2020-2021 Arm. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/news/20210205000735.doc
+++ b/news/20210205000735.doc
@@ -1,0 +1,1 @@
+Updated Copyright

--- a/news/20210205001245.bugfix
+++ b/news/20210205001245.bugfix
@@ -1,0 +1,1 @@
+The 0.8.6 release of the `licenseheaders` contains a bug. Pin its version until it is fixed upstream.

--- a/news/212102041830.bugfix
+++ b/news/212102041830.bugfix
@@ -1,0 +1,1 @@
+Fix for clones of private repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 [ProjectConfig]
@@ -34,6 +34,7 @@ python-dotenv="BSD-3-Clause"
 twine="Apache-2.0"
 jellyfish="BSD-2-Clause"
 packaging="either Apache-2.0 or BSD-2-Clause"
+importlib-metadata="Apache-2.0 or Python-2.0"
 
 [AutoVersionConfig]
 CONFIG_NAME = "DEFAULT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ twine="Apache-2.0"
 jellyfish="BSD-2-Clause"
 packaging="either Apache-2.0 or BSD-2-Clause"
 importlib-metadata="Apache-2.0 or Python-2.0"
+typing-extensions="PSF-2.0"
 
 [AutoVersionConfig]
 CONFIG_NAME = "DEFAULT"

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "twine",
         "boto3",
         "packaging",
-        "licenseheaders",
+        "licenseheaders<0.8.6",
         "spdx-tools",
         "license-expression",
         "wcmatch",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Package definition for PyPI."""

--- a/tests/assert_news/test_news_file_validation.py
+++ b/tests/assert_news/test_news_file_validation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import mock, TestCase

--- a/tests/assert_news/test_news_files_validation.py
+++ b/tests/assert_news/test_news_files_validation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib

--- a/tests/filesystem/test_filesystem_helpers.py
+++ b/tests/filesystem/test_filesystem_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import os

--- a/tests/generate_docs/test_generate_docs_python.py
+++ b/tests/generate_docs/test_generate_docs_python.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib

--- a/tests/git_helper/test_git_helpers.py
+++ b/tests/git_helper/test_git_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/hash/test_hash_generation.py
+++ b/tests/hash/test_hash_generation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/licensing/test_license_files.py
+++ b/tests/licensing/test_license_files.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from continuous_delivery_scripts.license_files import _to_copyright_date_string

--- a/tests/licensing/test_opensource_licences.py
+++ b/tests/licensing/test_opensource_licences.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/packaging/test_package_helpers.py
+++ b/tests/packaging/test_package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/python_helpers/test_python_helpers.py
+++ b/tests/python_helpers/test_python_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from continuous_delivery_scripts.utils.python.python_helpers import flatten_dictionary

--- a/tests/spdx/test_spdx_file.py
+++ b/tests/spdx/test_spdx_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/spdx/test_spdx_helper.py
+++ b/tests/spdx/test_spdx_helper.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/spdx/test_spdx_project.py
+++ b/tests/spdx/test_spdx_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/string_helpers/test_string_helpers.py
+++ b/tests/string_helpers/test_string_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/tag_and_release/test_update_documentation_python.py
+++ b/tests/tag_and_release/test_update_documentation_python.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Tests for  documentation update functions."""

--- a/tests/test_create_news_file.py
+++ b/tests/test_create_news_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm. All rights reserved.
+# Copyright (C) 2020-2021 Arm. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib


### PR DESCRIPTION
### Description

Fix for clones of private repositories

Current error when using scripts against private repositories:

>  File "/opt/hostedtoolcache/Python/3.9.1/x64/bin/cd-assert-news", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.9.1/x64/lib/python3.9/site-packages/continuous_delivery_scripts/assert_news.py", line 107, in main
    else ProjectTempClone(desired_branch_name=args.current_branch)
  File "/opt/hostedtoolcache/Python/3.9.1/x64/lib/python3.9/site-packages/continuous_delivery_scripts/utils/git_helpers.py", line 691, in __init__
    super().__init__(desired_branch_name=desired_branch_name, repository_to_clone=ProjectGitWrapper())
  File "/opt/hostedtoolcache/Python/3.9.1/x64/lib/python3.9/site-packages/continuous_delivery_scripts/utils/git_helpers.py", line 660, in __init__
    self._clone = GitClone.wrap(self._repo.clone(self._temporary_dir.path), initial_location=self._repo.root)
  File "/opt/hostedtoolcache/Python/3.9.1/x64/lib/python3.9/site-packages/continuous_delivery_scripts/utils/git_helpers.py", line 62, in clone
    git_clone = self.repo.clone_from(
  File "/opt/hostedtoolcache/Python/3.9.1/x64/lib/python3.9/site-packages/git/repo/base.py", line 1032, in clone_from
    return cls._clone(git, url, to_path, GitCmdObjectDB, progress, multi_options, **kwargs)
  File "/opt/hostedtoolcache/Python/3.9.1/x64/lib/python3.9/site-packages/git/repo/base.py", line 973, in _clone
    finalize_process(proc, stderr=stderr)
  File "/opt/hostedtoolcache/Python/3.9.1/x64/lib/python3.9/site-packages/git/util.py", line 329, in finalize_process
    proc.wait(**kwargs)
  File "/opt/hostedtoolcache/Python/3.9.1/x64/lib/python3.9/site-packages/git/cmd.py", line 408, in wait
    raise GitCommandError(self.args, status, errstr)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v --recurse-submodules https://github.com/Arm-Debug/cmsis-protobuf /tmp/tmp1pi8l_ox
  stderr: 'Cloning into '/tmp/tmp1pi8l_ox'...
fatal: could not read Username for 'https://github.com': No such device or address



### Test Coverage


- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
