### PR TITLE
Print version when determining the next one

### DIFF
--- a/continuous_delivery_scripts/tag_and_release.py
+++ b/continuous_delivery_scripts/tag_and_release.py
@@ -40,7 +40,7 @@ def tag_and_release(mode: CommitType, current_branch: Optional[str] = None) -> N
 
     """
     get_language_specifics().check_credentials()
-    is_new_version, version = version_project(mode)
+    is_new_version, version, _ = version_project(mode)
     logger.info(f"Current version: {version}")
     if not version:
         raise ValueError("Undefined version.")

--- a/news/20210205180027.feature
+++ b/news/20210205180027.feature
@@ -1,0 +1,1 @@
+Print new version on `cd-generate-news`


### PR DESCRIPTION
### Description

Print version when determining the next one

### Test Coverage

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
