### PR TITLE
modify development version to comprise build count

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,4 +23,4 @@ pre-commit = "*"
 allow_prereleases = true
 
 [packages]
-continuous-delivery-scripts = {path = "."}
+continuous-delivery-scripts = {editable = true, path = "."}

--- a/continuous_delivery_scripts/generate_news.py
+++ b/continuous_delivery_scripts/generate_news.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 from auto_version import auto_version_tool
 from continuous_delivery_scripts.utils.definitions import CommitType
+from continuous_delivery_scripts.utils.git_helpers import LocalProjectRepository
 from continuous_delivery_scripts.utils.configuration import configuration, ConfigurationVariable
 from continuous_delivery_scripts.utils.logging import log_exception, set_log_level
 from continuous_delivery_scripts.utils.filesystem_helpers import cd
@@ -85,13 +86,17 @@ def _update_version_string(
         version_elements: version elements
     """
     if commit_type == CommitType.DEVELOPMENT:
+        commit_count = version_elements.get(auto_version_tool.Constants.COMMIT_COUNT_FIELD)
+        if not commit_count:
+            with LocalProjectRepository() as git:
+                commit_count = git.get_commit_count()
         return "%s-%s.%s+%s" % (
             new_version,
             auto_version_tool.config.BUILD_TOKEN,
-            version_elements.get(auto_version_tool.Constants.COMMIT_COUNT_FIELD),
+            commit_count,
             version_elements.get(auto_version_tool.Constants.COMMIT_FIELD),
         )
-    return new_version
+        return new_version
 
 
 def _get_version_elements(native_version_elements: Dict[str, str]) -> Dict[str, str]:

--- a/continuous_delivery_scripts/generate_news.py
+++ b/continuous_delivery_scripts/generate_news.py
@@ -85,9 +85,10 @@ def _update_version_string(
         version_elements: version elements
     """
     if commit_type == CommitType.DEVELOPMENT:
-        return "%s-%s+%s" % (
+        return "%s-%s.%s+%s" % (
             new_version,
             auto_version_tool.config.BUILD_TOKEN,
+            version_elements.get(auto_version_tool.Constants.COMMIT_COUNT_FIELD),
             version_elements.get(auto_version_tool.Constants.COMMIT_FIELD),
         )
     return new_version

--- a/news/20210716174500.bugfix
+++ b/news/20210716174500.bugfix
@@ -1,0 +1,1 @@
+Fix development versions so that they can be used by any package managers i.e. pip and npm


### PR DESCRIPTION
### Description

Changing development version format so that it works for pip and npm


### Test Coverage

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
