### PR TITLE
make `cd-determine-version` command idempotent

### DIFF
--- a/continuous_delivery_scripts/generate_news.py
+++ b/continuous_delivery_scripts/generate_news.py
@@ -31,7 +31,7 @@ def version_project(commit_type: CommitType) -> Tuple[bool, Optional[str], Dict[
         (is new version, the new version)
     """
     use_news_files = commit_type in [CommitType.BETA, CommitType.RELEASE]
-    is_new_version, new_version, version_elements = calculate_version(commit_type, use_news_files)
+    is_new_version, new_version, version_elements = calculate_version(commit_type, use_news_files, True)
     _generate_changelog(new_version, use_news_files)
     return is_new_version, new_version, version_elements
 

--- a/continuous_delivery_scripts/get_version.py
+++ b/continuous_delivery_scripts/get_version.py
@@ -26,7 +26,7 @@ def get_project_version_string(commit_type: CommitType) -> str:
         (is new version, the new version)
     """
     use_news_files = commit_type in [CommitType.BETA, CommitType.RELEASE]
-    _, new_version, version_elements = calculate_version(commit_type, use_news_files)
+    _, new_version, version_elements = calculate_version(commit_type, use_news_files, False)
     version_string = determine_version_string(commit_type, new_version, version_elements)
     return version_string
 

--- a/continuous_delivery_scripts/utils/versioning.py
+++ b/continuous_delivery_scripts/utils/versioning.py
@@ -17,7 +17,9 @@ from continuous_delivery_scripts.utils.git_helpers import LocalProjectRepository
 logger = logging.getLogger(__name__)
 
 
-def calculate_version(commit_type: CommitType, use_news_files: bool) -> Tuple[bool, Optional[str], Dict[str, str]]:
+def calculate_version(
+    commit_type: CommitType, use_news_files: bool, record_state: bool
+) -> Tuple[bool, Optional[str], Dict[str, str]]:
     """Calculates the version for the release.
 
     eg. "0.1.2"
@@ -44,6 +46,7 @@ def calculate_version(commit_type: CommitType, use_news_files: bool) -> Tuple[bo
             enable_file_triggers=enable_file_triggers,
             commit_count_as=bump,
             config_path=project_config_path,
+            dry_run=not record_state,
         )
         # Autoversion second returned value is not actually the new version
         # There seem to be a bug in autoversion.

--- a/news/202108111624.bugfix
+++ b/news/202108111624.bugfix
@@ -1,0 +1,1 @@
+Made `cd-determine-version` idempotent

--- a/tests/versioning/test_versioning.py
+++ b/tests/versioning/test_versioning.py
@@ -10,12 +10,12 @@ from continuous_delivery_scripts.utils.definitions import CommitType
 class TestVersioning(unittest.TestCase):
     def test_calculate_version(self):
         for release_type in CommitType.choices():
-            _, new_version, version_elements = calculate_version(CommitType.RELEASE, False)
+            _, new_version, version_elements = calculate_version(CommitType.RELEASE, False, False)
             self.assertIsNotNone(new_version)
             self.assertNotEquals(new_version, "")
             self.assertIsNotNone(version_elements)
             self.assertGreater(len(version_elements), 0)
-            _, new_version, version_elements = calculate_version(CommitType.RELEASE, True)
+            _, new_version, version_elements = calculate_version(CommitType.RELEASE, True, False)
             self.assertIsNotNone(new_version)
             self.assertNotEquals(new_version, "")
             self.assertIsNotNone(version_elements)


### PR DESCRIPTION
### Description

Currently the version file is modified any time the command is called.
This is about changing this behaviour so that the state is not stored and hence, so that the command becomes idempotent

### Test Coverage

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
