### PR TITLE
Added precommit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,19 @@
+- id: assert-news
+  name: Assert news files
+  description: Assert that a news file has been added and describes the change.
+  entry: cd-assert-news -l
+  language: python
+  types: [file]
+  require_serial: true
+  verbose: true
+  always_run: true
+  pass_filenames: false    
+- id: licensing
+  name: licensing
+  entry: cd-license-files
+  language: python
+  types: [file]
+  require_serial: true
+  always_run: true
+  verbose: true
+  pass_filenames: false

--- a/news/202108131306.feature
+++ b/news/202108131306.feature
@@ -1,0 +1,1 @@
+Added a [pre-commit](https://pre-commit.com) hook for ease of use in other repositories


### PR DESCRIPTION
### Description

Added [pre-commit](https://pre-commit.com) hooks for ease of use in other repositories. This will allow pre-commit to manage the virtual environment for those hooks, so users don't need a pipenv shell activated for pre-commit checks to work.

### Test Coverage


- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
