### PR TITLE
Repository cleanup after release tagging

### DIFF
--- a/continuous_delivery_scripts/plugins/python.py
+++ b/continuous_delivery_scripts/plugins/python.py
@@ -165,6 +165,10 @@ class Python(BaseLanguage):
         """States whether project metadata can be retrieved."""
         return True
 
+    def should_include_spdx_in_package(self) -> bool:
+        """States whether the SPDX documents should be included in the package."""
+        return True
+
     def get_current_spdx_project(self) -> Optional[SpdxProject]:
         """Gets the current SPDX description."""
         return _get_current_spdx_project()

--- a/continuous_delivery_scripts/tag_and_release.py
+++ b/continuous_delivery_scripts/tag_and_release.py
@@ -50,7 +50,7 @@ def tag_and_release(mode: CommitType, current_branch: Optional[str] = None) -> N
     insert_licence_header(0)
     _update_repository(mode, is_new_version, version, current_branch)
     if is_new_version:
-        if spdx_project:
+        if spdx_project and get_language_specifics().should_include_spdx_in_package():
             _generate_spdx_reports(spdx_project)
         get_language_specifics().package_software(version)
         get_language_specifics().release_package_to_repository(version)
@@ -93,6 +93,9 @@ def _update_repository(mode: CommitType, is_new_version: bool, version: str, cur
             logger.info("Tagging commit")
             git.create_tag(get_language_specifics().get_version_tag(version), message=f"release {version}")
             git.force_push_tag()
+        git.fetch()
+        git.pull()
+        git.clean()
 
 
 def _generate_spdx_reports(project: SpdxProject) -> None:

--- a/continuous_delivery_scripts/utils/git_helpers.py
+++ b/continuous_delivery_scripts/utils/git_helpers.py
@@ -478,6 +478,21 @@ class GitWrapper:
         """
         self.repo.git.push(force=True, tags=True)
 
+    def is_dirty(self) -> bool:
+        """Determines whether repository is dirty.
+
+        Repository is considered dirty when git status returns elements which are not committed.
+        """
+        return self.repo.is_dirty(untracked_files=True)
+
+    def clean(self) -> None:
+        """Cleans the repository.
+
+        Performs a force clean.
+        """
+        if self.is_dirty():
+            self.repo.git.clean(force=True, x=True, d=True)
+
     def configure_for_github(self) -> None:
         """Reconfigures the repository.
 

--- a/continuous_delivery_scripts/utils/language_specifics_base.py
+++ b/continuous_delivery_scripts/utils/language_specifics_base.py
@@ -65,6 +65,10 @@ class BaseLanguage(ABC):
         """States whether project metadata can be retrieved."""
         return False
 
+    def should_include_spdx_in_package(self) -> bool:
+        """States whether the SPDX documents should be included in the package."""
+        return False
+
     @abstractmethod
     def generate_code_documentation(self, output_directory: Path, module_to_document: str) -> None:
         """Generates the code documentation."""

--- a/news/202108241231.feature
+++ b/news/202108241231.feature
@@ -1,0 +1,1 @@
+Added a clean repository step

--- a/tests/git_helper/test_git_helpers.py
+++ b/tests/git_helper/test_git_helpers.py
@@ -71,7 +71,7 @@ class TestGitTempClone(TestCase):
             self.assertIsNone(groups)
 
     def test_file_addition(self):
-        """Test basic git branch actions on the clone."""
+        """Test basic git add actions on the clone."""
         with ProjectTempClone(desired_branch_name="main") as clone:
             branch = clone.create_branch(f"test-{uuid4()}")
             clone.checkout(branch)
@@ -88,6 +88,22 @@ class TestGitTempClone(TestCase):
             self.assertEqual(previous_count + 1, clone.get_commit_count())
             added_files = [Path(clone.root).joinpath(f) for f in clone.list_files_added_on_current_branch()]
             self.assertTrue(test_file in added_files)
+
+    def test_repo_clean(self):
+        """Test basic git clean on the clone."""
+        with ProjectTempClone(desired_branch_name="main") as clone:
+            branch = clone.create_branch(f"test-{uuid4()}")
+            clone.checkout(branch)
+            self.assertTrue(len(clone.list_files_added_on_current_branch()) == 0)
+            test_file = Path(clone.root).joinpath(f"branch-test-{uuid4()}.txt")
+            test_file.touch()
+            uncommitted_changes = clone.uncommitted_changes
+            self.assertTrue(test_file in uncommitted_changes)
+            self.assertTrue(clone.is_dirty())
+            clone.clean()
+            self.assertFalse(clone.is_dirty())
+            uncommitted_changes = clone.uncommitted_changes
+            self.assertTrue(len(uncommitted_changes) == 0)
 
     def test_file_addition_with_paths_to_initial_repository(self):
         """Test basic git add on the clone."""


### PR DESCRIPTION
### Description

Added a clean up step after release tagging


### Test Coverage

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
