### PR TITLE
:sparkles: Tag with version shortcuts

### DIFF
--- a/continuous_delivery_scripts/get_version.py
+++ b/continuous_delivery_scripts/get_version.py
@@ -33,7 +33,7 @@ def get_project_version_string(commit_type: CommitType) -> str:
 
 def main() -> None:
     """Handle command line arguments to determine version string."""
-    parser = argparse.ArgumentParser(description="Determine project's version.")
+    parser = argparse.ArgumentParser(description="Determine project's new version.")
     parser.add_argument(
         "-t", "--release-type", help="type of release to perform", required=True, type=str, choices=CommitType.choices()
     )

--- a/continuous_delivery_scripts/plugins/ci.py
+++ b/continuous_delivery_scripts/plugins/ci.py
@@ -5,7 +5,7 @@
 """Plugin for CI projects."""
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 from continuous_delivery_scripts.spdx_report.spdx_project import SpdxProject
 from continuous_delivery_scripts.utils.configuration import configuration, ConfigurationVariable
@@ -63,6 +63,6 @@ class CI(BaseLanguage):
         """States whether the repository must be cleaned before packaging happens."""
         return True
 
-    def tag_release(self, git: GitWrapper, version: str) -> None:
+    def tag_release(self, git: GitWrapper, version: str, shortcuts: List[str]) -> None:
         """Tags release commit."""
-        super().tag_release(git, version)
+        super().tag_release(git, version, shortcuts)

--- a/continuous_delivery_scripts/plugins/golang.py
+++ b/continuous_delivery_scripts/plugins/golang.py
@@ -161,9 +161,9 @@ class Go(BaseLanguage):
         """States whether the repository must be cleaned before packaging happens."""
         return True
 
-    def tag_release(self, git: GitWrapper, version: str) -> None:
+    def tag_release(self, git: GitWrapper, version: str, shortcuts: List[str]) -> None:
         """Tags release commit."""
-        super().tag_release(git, version)
+        super().tag_release(git, version, shortcuts)
         go_tag = _determine_go_module_tag(self.get_version_tag(version))
         if go_tag:
             git.create_tag(go_tag, message=f"Golang module release: {go_tag}")

--- a/continuous_delivery_scripts/utils/configuration.py
+++ b/continuous_delivery_scripts/utils/configuration.py
@@ -88,6 +88,8 @@ class ConfigurationVariable(enum.Enum):
     """News file type for dependency update."""
     TAG_LATEST = 35
     """States whether the release should be tagged with `latest`"""
+    TAG_VERSION_SHORTCUTS = 36
+    """States whether the release should be tagged with shortcuts i.e. major, major+minor"""
 
     @staticmethod
     def choices() -> List[str]:
@@ -192,6 +194,7 @@ class StaticConfig(GenericConfig):
     AWS_BUCKET = "Unknown"
     AUTOGENERATE_NEWS_FILE_ON_DEPENDENCY_UPDATE = True
     TAG_LATEST = False
+    TAG_VERSION_SHORTCUTS = False
     DEPENDENCY_UPDATE_NEWS_MESSAGE = "Dependency upgrade: {message}"
     DEPENDENCY_UPDATE_NEWS_TYPE = NewsType.bugfix
     DEPENDENCY_UPDATE_BRANCH_PATTERN = r"^\s*[Dd]ependabot\/.+\/(?P<DEPENDENCY>.+)"

--- a/continuous_delivery_scripts/utils/language_specifics_base.py
+++ b/continuous_delivery_scripts/utils/language_specifics_base.py
@@ -7,7 +7,7 @@
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 from continuous_delivery_scripts.spdx_report.spdx_project import SpdxProject
 from continuous_delivery_scripts.utils.configuration import configuration, ConfigurationVariable
@@ -74,12 +74,15 @@ class BaseLanguage(ABC):
         """States whether the repository must be cleaned before packaging happens."""
         return False
 
-    def tag_release(self, git: GitWrapper, version: str) -> None:
+    def tag_release(self, git: GitWrapper, version: str, shortcuts: List[str]) -> None:
         """Tags release commit."""
         logger.info(f"Tagging commit as release {version}")
         git.create_tag(self.get_version_tag(version), message=f"release {version}")
         if configuration.get_value(ConfigurationVariable.TAG_LATEST):
             git.create_tag("latest", message="latest release")
+        if configuration.get_value(ConfigurationVariable.TAG_VERSION_SHORTCUTS):
+            for shortcut in shortcuts:
+                git.create_tag(self.get_version_tag(shortcut), message=f"{shortcut} release")
 
     @abstractmethod
     def generate_code_documentation(self, output_directory: Path, module_to_document: str) -> None:

--- a/continuous_delivery_scripts/utils/versioning.py
+++ b/continuous_delivery_scripts/utils/versioning.py
@@ -88,7 +88,7 @@ def determine_version_string(
 
 
 def determine_version_shortcuts(commit_type: CommitType, version_elements: Dict[str, str]) -> List[str]:
-    """Determine the different version shortcuts i.e. major, major.minor, pre depending on the release type
+    """Determine the different version shortcuts i.e. major, major.minor, pre depending on the release type.
 
     Args:
         commit_type: commit type

--- a/news/20221220194939.feature
+++ b/news/20221220194939.feature
@@ -1,0 +1,1 @@
+Added a way to tag releases with version shortcuts such as 1.0

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         # FIXME change when https://github.com/pdoc3/pdoc/issues/299 is fixed
         "pdoc3==0.10.0",
         "toml",
+        "semver~=2.13.0",
         "python-dotenv",
         "twine",
         "boto3",

--- a/tests/versioning/test_versioning.py
+++ b/tests/versioning/test_versioning.py
@@ -3,8 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest
-from continuous_delivery_scripts.utils.versioning import calculate_version, determine_version_string
+from continuous_delivery_scripts.utils.versioning import (
+    calculate_version,
+    determine_version_string,
+    determine_version_shortcuts,
+)
 from continuous_delivery_scripts.utils.definitions import CommitType
+from auto_version.auto_version_tool import definitions, config
 
 
 class TestVersioning(unittest.TestCase):
@@ -26,3 +31,41 @@ class TestVersioning(unittest.TestCase):
         self.assertEqual("1.1.1", determine_version_string(CommitType.BETA, "1.1.1", {}))
         self.assertTrue("1.1.1" in determine_version_string(CommitType.DEVELOPMENT, "1.1.1", {}))
         self.assertGreaterEqual(len(determine_version_string(CommitType.DEVELOPMENT, "1.1.1", {})), len("1.1.1"))
+
+    def test_determine_version_shortcuts(self):
+        self.assertListEqual(
+            ["1", "1.1"],
+            determine_version_shortcuts(
+                CommitType.RELEASE, {definitions.SemVerSigFig.major: "1", definitions.SemVerSigFig.minor: "1"}
+            ),
+        )
+        self.assertListEqual(
+            ["1"], determine_version_shortcuts(CommitType.RELEASE, {definitions.SemVerSigFig.major: "1"})
+        )
+        self.assertListEqual([], determine_version_shortcuts(CommitType.RELEASE, {definitions.SemVerSigFig.minor: "1"}))
+        self.assertListEqual(
+            ["1", "1.1", config.PRERELEASE_TOKEN],
+            determine_version_shortcuts(
+                CommitType.BETA, {definitions.SemVerSigFig.major: "1", definitions.SemVerSigFig.minor: "1"}
+            ),
+        )
+        self.assertTrue(
+            "1.1"
+            in determine_version_shortcuts(
+                CommitType.DEVELOPMENT, {definitions.SemVerSigFig.major: "1", definitions.SemVerSigFig.minor: "1"}
+            )
+        )
+        self.assertTrue(
+            "1"
+            in determine_version_shortcuts(
+                CommitType.DEVELOPMENT, {definitions.SemVerSigFig.major: "1", definitions.SemVerSigFig.minor: "1"}
+            )
+        )
+        self.assertGreaterEqual(
+            len(
+                determine_version_shortcuts(
+                    CommitType.DEVELOPMENT, {definitions.SemVerSigFig.major: "1", definitions.SemVerSigFig.minor: "1"}
+                )
+            ),
+            2,
+        )


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

Add the ability to tag a release with moving shortcuts such as what is done on DockerHub e.g. for `v1.2.3`, also add `v1`, `v1.2`, `latest` tags



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
