### PR TITLE
:zap: Improved `assert news` performance

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -116,7 +116,7 @@
         "filename": "continuous_delivery_scripts/utils/git_helpers.py",
         "hashed_secret": "9af3842326eadff7d85a55edfec67f6d8a3a259f",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 48
       }
     ],
     "tests/git_helper/htmlcov/status.json": [
@@ -425,5 +425,5 @@
       }
     ]
   },
-  "generated_at": "2022-12-22T00:31:43Z"
+  "generated_at": "2023-02-28T00:31:43Z"
 }

--- a/continuous_delivery_scripts/utils/git_helpers.py
+++ b/continuous_delivery_scripts/utils/git_helpers.py
@@ -7,11 +7,10 @@ import logging
 import os
 import re
 import shutil
-from pathlib import Path
-from typing import Optional, List, Union, Any, Tuple
-
 from git import Repo, Actor, GitCommandError
 from packaging import version
+from pathlib import Path
+from typing import Optional, List, Union, Any, Tuple
 
 from .configuration import configuration, ConfigurationVariable
 from .filesystem_helpers import TemporaryDirectory
@@ -546,6 +545,12 @@ class GitWrapper:
         except (IndexError, ValueError) as e:
             logger.warning(e)
             return None
+
+    def list_files_added_to_current_commit(self) -> List[str]:
+        """Returns a list of files added in the current commit."""
+        current_branch_commit = self.repo.commit(self.get_current_branch())
+        changes = self.get_changes_list(current_branch_commit, None, change_type="a")
+        return changes
 
     def list_files_added_on_current_branch(self) -> List[str]:
         """Returns a list of files changed against master branch."""

--- a/continuous_delivery_scripts/utils/git_helpers.py
+++ b/continuous_delivery_scripts/utils/git_helpers.py
@@ -400,13 +400,13 @@ class GitWrapper:
         return self.get_remote_branch(branch_name) is not None
 
     def _get_specific_changes(self, change_type: Optional[str], commit1: Any, commit2: Any) -> List[str]:
-        diff = []
-        if not (commit1 or commit2):
-            return []
+        diff = None
         if commit1:
             diff = commit1.diff(commit2) if commit2 else commit1.diff()
-        else:
+        elif commit2:
             diff = commit2.diff()
+        if not diff:
+            return []
         if change_type:
             change_type = change_type.upper()
             change_type = change_type if change_type in diff.change_type else None

--- a/news/20230228103345.bugfix
+++ b/news/20230228103345.bugfix
@@ -1,0 +1,1 @@
+:zap: Improved the performance of `assert news` for cases where news files are added to the current commit

--- a/tests/assert_news/test_news_files_validation.py
+++ b/tests/assert_news/test_news_files_validation.py
@@ -13,6 +13,11 @@ class TestFindNewsFiles(TestCase):
     def test_returns_newly_added_news_files(self):
         """Given added files in git, it returns absolute paths to added news files."""
         fake_git_wrapper = mock.Mock(spec_set=GitWrapper)
+        fake_git_wrapper.list_files_added_to_current_commit.return_value = [
+            "foo/bar.py",
+            "news/1234.txt",
+            "news/wat.html",
+        ]
         fake_git_wrapper.list_files_added_on_current_branch.return_value = [
             "foo/bar.py",
             "news/1234.txt",
@@ -23,6 +28,28 @@ class TestFindNewsFiles(TestCase):
 
         subject = find_news_files(git=fake_git_wrapper, root_dir=root_dir, news_dir=news_dir)
 
+        fake_git_wrapper.list_files_added_to_current_commit.assert_called_once()
+        fake_git_wrapper.list_files_added_on_current_branch.assert_not_called()
+        self.assertEqual(
+            subject, [str(pathlib.Path(root_dir, "news/1234.txt")), str(pathlib.Path(root_dir, "news/wat.html"))]
+        )
+
+    def test_returns_previously_added_news_files(self):
+        """Given added files in git, it returns absolute paths to added news files."""
+        fake_git_wrapper = mock.Mock(spec_set=GitWrapper)
+        fake_git_wrapper.list_files_added_to_current_commit.return_value = []
+        fake_git_wrapper.list_files_added_on_current_branch.return_value = [
+            "foo/bar.py",
+            "news/1234.txt",
+            "news/wat.html",
+        ]
+        news_dir = "news/"
+        root_dir = "/root/"
+
+        subject = find_news_files(git=fake_git_wrapper, root_dir=root_dir, news_dir=news_dir)
+
+        fake_git_wrapper.list_files_added_to_current_commit.assert_called_once()
+        fake_git_wrapper.list_files_added_on_current_branch.assert_called_once()
         self.assertEqual(
             subject, [str(pathlib.Path(root_dir, "news/1234.txt")), str(pathlib.Path(root_dir, "news/wat.html"))]
         )

--- a/tests/git_helper/test_git_helpers.py
+++ b/tests/git_helper/test_git_helpers.py
@@ -81,6 +81,7 @@ class TestGitTempClone(TestCase):
             self.assertEqual(clone.get_current_branch(), branch)
             self.assertTrue(clone.is_current_branch_feature())
             self.assertTrue(len(clone.list_files_added_on_current_branch()) == 0)
+            self.assertTrue(len(clone.list_files_added_to_current_commit()) == 0)
 
     def test_current_branch(self):
         """Ensures current branch is as expected."""
@@ -105,6 +106,7 @@ class TestGitTempClone(TestCase):
             branch = clone.create_branch(f"test-{uuid4()}")
             clone.checkout(branch)
             self.assertTrue(len(clone.list_files_added_on_current_branch()) == 0)
+            self.assertTrue(len(clone.list_files_added_to_current_commit()) == 0)
             previous_hash = clone.get_commit_hash()
             previous_count = clone.get_commit_count()
             test_file = Path(clone.root).joinpath(f"branch-test-{uuid4()}.txt")
@@ -115,8 +117,10 @@ class TestGitTempClone(TestCase):
             clone.commit("Test commit")
             self.assertNotEqual(previous_hash, clone.get_commit_hash())
             self.assertEqual(previous_count + 1, clone.get_commit_count())
-            added_files = [Path(clone.root).joinpath(f) for f in clone.list_files_added_on_current_branch()]
-            self.assertTrue(test_file in added_files)
+            added_files_to_commit = [Path(clone.root).joinpath(f) for f in clone.list_files_added_to_current_commit()]
+            self.assertTrue(test_file in added_files_to_commit)
+            added_files_to_branch = [Path(clone.root).joinpath(f) for f in clone.list_files_added_on_current_branch()]
+            self.assertTrue(test_file in added_files_to_branch)
 
     def test_repo_clean(self):
         """Test basic git clean on the clone."""
@@ -124,6 +128,7 @@ class TestGitTempClone(TestCase):
             branch = clone.create_branch(f"test-{uuid4()}")
             clone.checkout(branch)
             self.assertTrue(len(clone.list_files_added_on_current_branch()) == 0)
+            self.assertTrue(len(clone.list_files_added_to_current_commit()) == 0)
             test_file = Path(clone.root).joinpath(f"branch-test-{uuid4()}.txt")
             test_file.touch()
             uncommitted_changes = clone.uncommitted_changes
@@ -140,6 +145,7 @@ class TestGitTempClone(TestCase):
             branch = clone.create_branch(f"test-{uuid4()}")
             clone.checkout(branch)
             self.assertTrue(len(clone.list_files_added_on_current_branch()) == 0)
+            self.assertTrue(len(clone.list_files_added_to_current_commit()) == 0)
             test_file1 = Path(clone.root).joinpath(f"branch-test-{uuid4()}.txt")
             test_file1.touch()
             test_file2 = Path(clone.root).joinpath(f"branch-test-{uuid4()}.txt")
@@ -166,5 +172,7 @@ class TestGitTempClone(TestCase):
             self.assertTrue(clone.get_corresponding_path(test_file) in uncommitted_changes)
             clone.add(test_file)
             clone.commit("Test commit")
+            added_files_to_commit = [Path(git.root).joinpath(f) for f in clone.list_files_added_to_current_commit()]
             added_files = [Path(git.root).joinpath(f) for f in clone.list_files_added_on_current_branch()]
         self.assertTrue(test_file in added_files)
+        self.assertTrue(test_file in added_files_to_commit)

--- a/tests/git_helper/test_git_helpers.py
+++ b/tests/git_helper/test_git_helpers.py
@@ -81,7 +81,6 @@ class TestGitTempClone(TestCase):
             self.assertEqual(clone.get_current_branch(), branch)
             self.assertTrue(clone.is_current_branch_feature())
             self.assertTrue(len(clone.list_files_added_on_current_branch()) == 0)
-            self.assertTrue(len(clone.list_files_added_to_current_commit()) == 0)
 
     def test_current_branch(self):
         """Ensures current branch is as expected."""
@@ -106,7 +105,6 @@ class TestGitTempClone(TestCase):
             branch = clone.create_branch(f"test-{uuid4()}")
             clone.checkout(branch)
             self.assertTrue(len(clone.list_files_added_on_current_branch()) == 0)
-            self.assertTrue(len(clone.list_files_added_to_current_commit()) == 0)
             previous_hash = clone.get_commit_hash()
             previous_count = clone.get_commit_count()
             test_file = Path(clone.root).joinpath(f"branch-test-{uuid4()}.txt")
@@ -128,7 +126,6 @@ class TestGitTempClone(TestCase):
             branch = clone.create_branch(f"test-{uuid4()}")
             clone.checkout(branch)
             self.assertTrue(len(clone.list_files_added_on_current_branch()) == 0)
-            self.assertTrue(len(clone.list_files_added_to_current_commit()) == 0)
             test_file = Path(clone.root).joinpath(f"branch-test-{uuid4()}.txt")
             test_file.touch()
             uncommitted_changes = clone.uncommitted_changes
@@ -145,7 +142,6 @@ class TestGitTempClone(TestCase):
             branch = clone.create_branch(f"test-{uuid4()}")
             clone.checkout(branch)
             self.assertTrue(len(clone.list_files_added_on_current_branch()) == 0)
-            self.assertTrue(len(clone.list_files_added_to_current_commit()) == 0)
             test_file1 = Path(clone.root).joinpath(f"branch-test-{uuid4()}.txt")
             test_file1.touch()
             test_file2 = Path(clone.root).joinpath(f"branch-test-{uuid4()}.txt")


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

Improved `assert news` performance by first looking for news file in the current commit before exploring the whole branch.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
