### PR TITLE
:gear: Change Changelog release title formatting

### DIFF
--- a/news/20230228130522.misc
+++ b/news/20230228130522.misc
@@ -1,0 +1,1 @@
+:gear: Improve changelog formatting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ patch = "news/*.bugfix"
 directory = "news"
 filename = "CHANGELOG.md"
 package = "continuous_delivery_scripts"
-title_format = "{version} ({project_date})"
+title_format = false
 start_string = """
 [//]: # (begin_release_notes)
 """


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

Changed the configuration of `towncrier` so that the release title in the changelog is better formatted. `towncrier` is the tool used to perform the changelog generation.



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
