### PR TITLE
:sparkles: Extended `cd-create-news`  to specify reference number

### DIFF
--- a/continuous_delivery_scripts/create_news_file.py
+++ b/continuous_delivery_scripts/create_news_file.py
@@ -29,9 +29,10 @@ def main() -> int:
     parser.add_argument(
         "-t", "--type", help="News type to create.", choices=[t.name for t in NewsType], default="feature"
     )
+    parser.add_argument("-n", "--ref-number", help="Reference number of the news file to use", required=False)
 
     args = parser.parse_args()
-    created_file = create_news_file(str(NEWS_DIR), args.news_text, NewsType[args.type])
+    created_file = create_news_file(str(NEWS_DIR), args.ref_number, args.news_text, NewsType[args.type])
 
     try:
         validate_news_file(created_file)

--- a/continuous_delivery_scripts/utils/news_file.py
+++ b/continuous_delivery_scripts/utils/news_file.py
@@ -7,7 +7,7 @@ import enum
 import pathlib
 import logging
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -23,21 +23,21 @@ class NewsType(enum.Enum):
     removal = 5
 
 
-def create_news_file(news_dir: str, news_text: str, news_type: Any) -> pathlib.Path:
+def create_news_file(news_dir: str, news_ref: Optional[str], news_text: str, news_type: Any) -> pathlib.Path:
     """Facilitates creating a news file, determining its file name based on the type."""
     message_type = NewsType.misc
     if isinstance(news_type, str):
         message_type = NewsType[news_type]
     elif isinstance(news_type, NewsType):
         message_type = news_type
-    file_path = determine_news_file_path(news_dir, message_type)
+    file_path = determine_news_file_path(news_dir, news_ref, message_type)
     _write_file(file_path, news_text)
     return file_path
 
 
-def determine_news_file_path(news_dir: str, news_type: NewsType) -> pathlib.Path:
+def determine_news_file_path(news_dir: str, news_ref: Optional[str], news_type: NewsType) -> pathlib.Path:
     """Returns an available file path for given news type."""
-    news_file_name = determine_basic_new_news_file_name()
+    news_file_name = news_ref if news_ref else determine_basic_new_news_file_name()
     news_file_path = pathlib.Path(news_dir, f"{news_file_name}.{news_type.name}")
     inc = 0
     while news_file_path.exists():

--- a/news/20230301133846.feature
+++ b/news/20230301133846.feature
@@ -1,0 +1,1 @@
+:sparkles: Extended `create-news` so that the reference number can be specified

--- a/tests/news_file/test_create_news_file.py
+++ b/tests/news_file/test_create_news_file.py
@@ -26,10 +26,10 @@ class TestCreateNewsFile(TestCase):
         news_text = "Cool feature"
         news_type = NewsType.feature
 
-        file_path = create_news_file(NEWS_DIR, news_text, news_type)
+        file_path = create_news_file(NEWS_DIR, None, news_text, news_type)
 
         self.assertEqual(file_path, news_file_path)
-        determine_news_file_path.assert_called_once_with(NEWS_DIR, news_type)
+        determine_news_file_path.assert_called_once_with(NEWS_DIR, None, news_type)
         _write_file.assert_called_once_with(file_path, news_text)
 
     @mock.patch("continuous_delivery_scripts.utils.news_file.determine_news_file_path")
@@ -40,10 +40,36 @@ class TestCreateNewsFile(TestCase):
         news_text = "Cool feature"
         news_type = NewsType.feature
 
-        file_path = create_news_file(NEWS_DIR, news_text, news_type.name)
+        file_path = create_news_file(NEWS_DIR, None, news_text, news_type.name)
 
         self.assertEqual(file_path, news_file_path)
-        determine_news_file_path.assert_called_once_with(NEWS_DIR, news_type)
+        determine_news_file_path.assert_called_once_with(NEWS_DIR, None, news_type)
+        _write_file.assert_called_once_with(file_path, news_text)
+
+    @mock.patch("continuous_delivery_scripts.utils.news_file.determine_basic_new_news_file_name")
+    @mock.patch("continuous_delivery_scripts.utils.news_file._write_file")
+    def test_creates_a_file_with_news_reference(self, _write_file, determine_basic_new_news_file_name):
+        determine_basic_new_news_file_name.return_value = "1234501.feature"
+        news_text = "Cool feature"
+        news_type = NewsType.feature
+        ref = "123456"
+        expected_file_path = pathlib.Path(NEWS_DIR, f"{ref}.feature")
+        file_path = create_news_file(NEWS_DIR, ref, news_text, news_type.name)
+
+        self.assertEqual(file_path, expected_file_path)
+        _write_file.assert_called_once_with(file_path, news_text)
+
+    @mock.patch("continuous_delivery_scripts.utils.news_file.determine_basic_new_news_file_name")
+    @mock.patch("continuous_delivery_scripts.utils.news_file._write_file")
+    def test_creates_a_file_without_news_reference(self, _write_file, determine_basic_new_news_file_name):
+        expected_file_name = "1234501"
+        determine_basic_new_news_file_name.return_value = expected_file_name
+        news_text = "Cool feature"
+        news_type = NewsType.feature
+
+        file_path = create_news_file(NEWS_DIR, None, news_text, news_type.name)
+
+        self.assertEqual(file_path, pathlib.Path(NEWS_DIR, f"{expected_file_name}.feature"))
         _write_file.assert_called_once_with(file_path, news_text)
 
 
@@ -59,7 +85,7 @@ class TestDetermineNewsFilePath(TestCase):
                     pathlib.Path(tmp_dir, f"{news_file_path_today}.{news_type.name}").touch()
                     pathlib.Path(tmp_dir, f"{news_file_path_today}01.{news_type.name}").touch()
 
-                    file_path = determine_news_file_path(NEWS_DIR, news_type)
+                    file_path = determine_news_file_path(NEWS_DIR, None, news_type)
 
                     self.assertEqual(file_path, pathlib.Path(news_dir, f"{news_file_name_today}02.{news_type.name}"))
 


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

- the reference number used in the news file name can now be specified from the command line


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
