### PR TITLE
:bug: Fix news file automatic creation

### DIFF
--- a/continuous_delivery_scripts/assert_news.py
+++ b/continuous_delivery_scripts/assert_news.py
@@ -120,6 +120,7 @@ def generate_news_file(git: GitWrapper, news_dir: pathlib.Path) -> pathlib.Path:
     logger.info(f"Generating a news file with content: {message}...")
     return create_news_file(
         str(news_dir),
+        None,
         message,
         configuration.get_value(ConfigurationVariable.DEPENDENCY_UPDATE_NEWS_TYPE),
     )

--- a/news/20230301144720.feature
+++ b/news/20230301144720.feature
@@ -1,0 +1,1 @@
+:bug: Fixed news file automatic creation for dependency updates


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

Fix news file automatic creation


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
