### PR TITLE
:bug: Fix the python error appearing from python > 3.11

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 ### Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 ### Description

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   python_cache_macOS_path: ~/Library/Caches/pip
   python_cache_windows_path: ~\AppData\Local\pip\Cache
   python_cache_ubuntu_path: ~/.cache/pip
-  pipenv_version: 2022.11.25
+  pipenv_version: 2024.4.0
   python_version: '3.11'
 
 jobs:
@@ -166,7 +166,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest ] # FIXME add other platforms when much quicker macOS-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         multi-platform:
           - ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         #        include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest ] # FIXME add other platforms when much quicker macOS-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"] # FIXME Test on later python versions, "3.12", "3.13"]
         multi-platform:
           - ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         #        include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 # Changelog

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 # Contributor Covenant Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 # Contribution Guide

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 # Development and Testing

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 # Known Issues

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,6 @@ continuous-delivery-scripts = {editable = true, path = "."}
 allow_prereleases = false
 
 [packages]
-continuous-delivery-scripts = {editable = true, path = "."}
 types-toml = "*"
 types-setuptools = "*"
+continuous-delivery-scripts = {file = ".", editable = true}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 # Automation Scripts for CI/CD

--- a/continuous_delivery_scripts/__init__.py
+++ b/continuous_delivery_scripts/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Scripts and utilities used by the CI pipeline."""

--- a/continuous_delivery_scripts/_version.py
+++ b/continuous_delivery_scripts/_version.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """The version number is based on semantic versioning.

--- a/continuous_delivery_scripts/assert_news.py
+++ b/continuous_delivery_scripts/assert_news.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Checks if valid news files are created for changes in the project."""

--- a/continuous_delivery_scripts/create_news_file.py
+++ b/continuous_delivery_scripts/create_news_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Easy news files generation.

--- a/continuous_delivery_scripts/generate_docs.py
+++ b/continuous_delivery_scripts/generate_docs.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Generates documentation."""

--- a/continuous_delivery_scripts/generate_news.py
+++ b/continuous_delivery_scripts/generate_news.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Handles usage of towncrier for automated changelog generation and pyautoversion for versioning."""

--- a/continuous_delivery_scripts/get_config.py
+++ b/continuous_delivery_scripts/get_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Retrieves configuration values."""

--- a/continuous_delivery_scripts/get_version.py
+++ b/continuous_delivery_scripts/get_version.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Determine the project new version."""

--- a/continuous_delivery_scripts/language_specifics.py
+++ b/continuous_delivery_scripts/language_specifics.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Language plugins Loader."""

--- a/continuous_delivery_scripts/license_files.py
+++ b/continuous_delivery_scripts/license_files.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Apply copyright and licensing to all source files present in a project.

--- a/continuous_delivery_scripts/plugins/__init__.py
+++ b/continuous_delivery_scripts/plugins/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Language specific actions."""

--- a/continuous_delivery_scripts/plugins/basic.py
+++ b/continuous_delivery_scripts/plugins/basic.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Basic plugin."""

--- a/continuous_delivery_scripts/plugins/ci.py
+++ b/continuous_delivery_scripts/plugins/ci.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for CI projects."""

--- a/continuous_delivery_scripts/plugins/docker.py
+++ b/continuous_delivery_scripts/plugins/docker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for Docker projects."""

--- a/continuous_delivery_scripts/plugins/github_actions.py
+++ b/continuous_delivery_scripts/plugins/github_actions.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for CI projects."""

--- a/continuous_delivery_scripts/plugins/golang.py
+++ b/continuous_delivery_scripts/plugins/golang.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for Golang projects."""

--- a/continuous_delivery_scripts/plugins/noop.py
+++ b/continuous_delivery_scripts/plugins/noop.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """No Operation plugin."""

--- a/continuous_delivery_scripts/plugins/python.py
+++ b/continuous_delivery_scripts/plugins/python.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for Python projects."""

--- a/continuous_delivery_scripts/report_third_party_ip.py
+++ b/continuous_delivery_scripts/report_third_party_ip.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Script providing information about licensing and third party IP in order to comply with OpenChain.

--- a/continuous_delivery_scripts/spdx_report/__init__.py
+++ b/continuous_delivery_scripts/spdx_report/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Module in charge of handling SPDX documents.

--- a/continuous_delivery_scripts/spdx_report/spdx_dependency.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_dependency.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of dependency SPDX Document."""

--- a/continuous_delivery_scripts/spdx_report/spdx_document.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_document.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX Document."""

--- a/continuous_delivery_scripts/spdx_report/spdx_file.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX File."""

--- a/continuous_delivery_scripts/spdx_report/spdx_helpers.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Facilities regarding SPDX.

--- a/continuous_delivery_scripts/spdx_report/spdx_helpers.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_helpers.py
@@ -33,8 +33,8 @@ from continuous_delivery_scripts.utils.third_party_licences import simplify_lice
 logger = logging.getLogger(__name__)
 
 # Copyright similar to the regex defined in flake8-copyright
-COPYRIGHT_PATTERN = r"(?i)Copyright.*$"
-COPYRIGHT_REGEX_PATTERN = re.compile(COPYRIGHT_PATTERN, re.MULTILINE)
+COPYRIGHT_PATTERN = r"Copyright.*$"
+COPYRIGHT_REGEX_PATTERN = re.compile(COPYRIGHT_PATTERN, flags=re.MULTILINE | re.IGNORECASE)
 # Specification of the identifier based on https://spdx.org/spdx-specification-21-web-version#h.twlc0ztnng3b
 # and https://spdx.org/ids-how
 SPDX_LICENCE_IDENTIFIER_PATTERN = r"SPDX-License-Identifier: ([\.\w+\-\(\)\s]+)[\*]?$"

--- a/continuous_delivery_scripts/spdx_report/spdx_package.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_package.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX Package."""

--- a/continuous_delivery_scripts/spdx_report/spdx_project.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX report for a Python project."""

--- a/continuous_delivery_scripts/spdx_report/spdx_summary.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_summary.py
@@ -63,11 +63,13 @@ class SummaryGenerator:
             "name": self.project.name,
             "compliance": global_compliance,
             "compliance_details": (
-                f"Project [{self.project.name}]'s licence is compliant: {self.project.licence}."
-                "All its dependencies are also compliant licence-wise."
-            )
-            if global_compliance
-            else f"Project [{self.project.name}] or one, at least, of its dependencies has a non compliant licence",
+                (
+                    f"Project [{self.project.name}]'s licence is compliant: {self.project.licence}."
+                    "All its dependencies are also compliant licence-wise."
+                )
+                if global_compliance
+                else f"Project [{self.project.name}] or one, at least, of its dependencies has a non compliant licence"
+            ),
         }
         arguments["packages"] = description_list
         arguments["render_time"] = datetime.datetime.now()
@@ -105,12 +107,14 @@ class SummaryGenerator:
             "licence": p.licence,
             "is_compliant": is_compliant,
             "mark_as_problematic": not is_licence_compliant,
-            "licence_compliance_details": "Licence is compliant."
-            if is_licence_compliant
-            else (
-                f"Package's licence manually checked: {manual_check_details}"
-                if package_manually_checked
-                else "Licence is not compliant according to project's configuration."
+            "licence_compliance_details": (
+                "Licence is compliant."
+                if is_licence_compliant
+                else (
+                    f"Package's licence manually checked: {manual_check_details}"
+                    if package_manually_checked
+                    else "Licence is not compliant according to project's configuration."
+                )
             ),
         }
 

--- a/continuous_delivery_scripts/spdx_report/spdx_summary.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_summary.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Summary generators."""

--- a/continuous_delivery_scripts/tag_and_release.py
+++ b/continuous_delivery_scripts/tag_and_release.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Orchestrates release process."""

--- a/continuous_delivery_scripts/utils/__init__.py
+++ b/continuous_delivery_scripts/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility scripts to abstract and assist with scripts run in the CI."""

--- a/continuous_delivery_scripts/utils/aws_helpers.py
+++ b/continuous_delivery_scripts/utils/aws_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for interacting with AWS services such as S3.

--- a/continuous_delivery_scripts/utils/configuration.py
+++ b/continuous_delivery_scripts/utils/configuration.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities in charge of fetching configuration values for the ci scripts."""

--- a/continuous_delivery_scripts/utils/definitions.py
+++ b/continuous_delivery_scripts/utils/definitions.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Place to store generic project concepts for the ci scripts."""

--- a/continuous_delivery_scripts/utils/filesystem_helpers.py
+++ b/continuous_delivery_scripts/utils/filesystem_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers with regards to actions on the filesystem."""

--- a/continuous_delivery_scripts/utils/git_helpers.py
+++ b/continuous_delivery_scripts/utils/git_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility script to abstract git operations for our CI scripts."""

--- a/continuous_delivery_scripts/utils/hash_helpers.py
+++ b/continuous_delivery_scripts/utils/hash_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for calculating hashes or UUID."""

--- a/continuous_delivery_scripts/utils/language_specifics_base.py
+++ b/continuous_delivery_scripts/utils/language_specifics_base.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Base class for all Language plugins."""

--- a/continuous_delivery_scripts/utils/logging.py
+++ b/continuous_delivery_scripts/utils/logging.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for logging errors according to severity of the exception."""

--- a/continuous_delivery_scripts/utils/news_file.py
+++ b/continuous_delivery_scripts/utils/news_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers with regards to news files."""

--- a/continuous_delivery_scripts/utils/noop/__init__.py
+++ b/continuous_delivery_scripts/utils/noop/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility scripts specific to noop."""

--- a/continuous_delivery_scripts/utils/noop/package_helpers.py
+++ b/continuous_delivery_scripts/utils/noop/package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities for retrieving NoOp's package information."""

--- a/continuous_delivery_scripts/utils/package_helpers.py
+++ b/continuous_delivery_scripts/utils/package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities for retrieving Python's package information."""

--- a/continuous_delivery_scripts/utils/python/__init__.py
+++ b/continuous_delivery_scripts/utils/python/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility scripts specific to python."""

--- a/continuous_delivery_scripts/utils/python/package_helpers.py
+++ b/continuous_delivery_scripts/utils/python/package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities for retrieving Python's package information."""

--- a/continuous_delivery_scripts/utils/python/python_helpers.py
+++ b/continuous_delivery_scripts/utils/python/python_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities around python language."""

--- a/continuous_delivery_scripts/utils/string_helpers.py
+++ b/continuous_delivery_scripts/utils/string_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities regarding string handling."""

--- a/continuous_delivery_scripts/utils/third_party_licences.py
+++ b/continuous_delivery_scripts/utils/third_party_licences.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Third party licences."""

--- a/continuous_delivery_scripts/utils/versioning.py
+++ b/continuous_delivery_scripts/utils/versioning.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers with regards to versioning."""

--- a/docs/assert_news.html
+++ b/docs/assert_news.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/create_news_file.html
+++ b/docs/create_news_file.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/generate_docs.html
+++ b/docs/generate_docs.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/generate_news.html
+++ b/docs/generate_news.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/get_config.html
+++ b/docs/get_config.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/get_version.html
+++ b/docs/get_version.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/language_specifics.html
+++ b/docs/language_specifics.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/license_files.html
+++ b/docs/license_files.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/basic.html
+++ b/docs/plugins/basic.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/ci.html
+++ b/docs/plugins/ci.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/docker.html
+++ b/docs/plugins/docker.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/github_actions.html
+++ b/docs/plugins/github_actions.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/golang.html
+++ b/docs/plugins/golang.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/index.html
+++ b/docs/plugins/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/noop.html
+++ b/docs/plugins/noop.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/plugins/python.html
+++ b/docs/plugins/python.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/report_third_party_ip.html
+++ b/docs/report_third_party_ip.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/index.html
+++ b/docs/spdx_report/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_dependency.html
+++ b/docs/spdx_report/spdx_dependency.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_document.html
+++ b/docs/spdx_report/spdx_document.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_file.html
+++ b/docs/spdx_report/spdx_file.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_helpers.html
+++ b/docs/spdx_report/spdx_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_package.html
+++ b/docs/spdx_report/spdx_package.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_project.html
+++ b/docs/spdx_report/spdx_project.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_summary.html
+++ b/docs/spdx_report/spdx_summary.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/tag_and_release.html
+++ b/docs/tag_and_release.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/third_party_IP_report.html
+++ b/docs/third_party_IP_report.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/aws_helpers.html
+++ b/docs/utils/aws_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/configuration.html
+++ b/docs/utils/configuration.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/definitions.html
+++ b/docs/utils/definitions.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/filesystem_helpers.html
+++ b/docs/utils/filesystem_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/git_helpers.html
+++ b/docs/utils/git_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/hash_helpers.html
+++ b/docs/utils/hash_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/index.html
+++ b/docs/utils/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/language_specifics_base.html
+++ b/docs/utils/language_specifics_base.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/logging.html
+++ b/docs/utils/logging.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/news_file.html
+++ b/docs/utils/news_file.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/noop/index.html
+++ b/docs/utils/noop/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/noop/package_helpers.html
+++ b/docs/utils/noop/package_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/package_helpers.html
+++ b/docs/utils/package_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/python/index.html
+++ b/docs/utils/python/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/python/package_helpers.html
+++ b/docs/utils/python/package_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/python/python_helpers.html
+++ b/docs/utils/python/python_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/string_helpers.html
+++ b/docs/utils/string_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/third_party_licences.html
+++ b/docs/utils/third_party_licences.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/versioning.html
+++ b/docs/utils/versioning.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+-- Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/news/20250109163919.bugfix
+++ b/news/20250109163919.bugfix
@@ -1,0 +1,1 @@
+:bug: Fix the python error appearing from python > 3.11

--- a/news/20250109170328.misc
+++ b/news/20250109170328.misc
@@ -1,0 +1,1 @@
+:gear: License all the source files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 [ProjectConfig]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,17 @@ tomli="MIT"
 markdown-it-py="MIT"
 mdurl="MIT"
 cryptography="((Apache-2.0 OR BSD-3-Clause) AND PSF-2.0)"
+click="BSD-3-Clause"
+click-default-group="BSD-3-Clause"
+urllib3="MIT"
+incremental="MIT"
+jaraco-functools="MIT"
+jaraco-context="MIT"
+importlib_metadata="Apache-2.0"
+docutils="BSD-3-Clause"
+backports-tarfile="MIT"
+
+
 
 [AutoVersionConfig]
 CONFIG_NAME = "DEFAULT"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Package definition for PyPI."""

--- a/tests/assert_news/test_news_file_validation.py
+++ b/tests/assert_news/test_news_file_validation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import mock, TestCase

--- a/tests/assert_news/test_news_files_validation.py
+++ b/tests/assert_news/test_news_files_validation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib

--- a/tests/filesystem/test_filesystem_helpers.py
+++ b/tests/filesystem/test_filesystem_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import os

--- a/tests/generate_docs/test_generate_docs_python.py
+++ b/tests/generate_docs/test_generate_docs_python.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib

--- a/tests/git_helper/test_git_helpers.py
+++ b/tests/git_helper/test_git_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/hash/test_hash_generation.py
+++ b/tests/hash/test_hash_generation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/licensing/test_license_files.py
+++ b/tests/licensing/test_license_files.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/licensing/test_opensource_licences.py
+++ b/tests/licensing/test_opensource_licences.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/news_file/test_create_news_file.py
+++ b/tests/news_file/test_create_news_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib

--- a/tests/packaging/test_package_helpers.py
+++ b/tests/packaging/test_package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import time

--- a/tests/python_helpers/test_python_helpers.py
+++ b/tests/python_helpers/test_python_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from continuous_delivery_scripts.utils.python.python_helpers import flatten_dictionary

--- a/tests/spdx/test_spdx_file.py
+++ b/tests/spdx/test_spdx_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/spdx/test_spdx_helper.py
+++ b/tests/spdx/test_spdx_helper.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/spdx/test_spdx_project.py
+++ b/tests/spdx/test_spdx_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/string_helpers/test_string_helpers.py
+++ b/tests/string_helpers/test_string_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/tag_and_release/test_update_documentation_python.py
+++ b/tests/tag_and_release/test_update_documentation_python.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Tests for  documentation update functions."""

--- a/tests/versioning/test_versioning.py
+++ b/tests/versioning/test_versioning.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

:bug: Fix the python error appearing from python > 3.11



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
