### PR TITLE
:sparkles: commands to deal with secrets management

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 ### Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 ### Description

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,18 +149,59 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install "setuptools<81" detect-secrets[gibberish]==1.5.0
           python -m pip list
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-      # FIXME gitleaks requires now a licence
-      # - name: Check for secrets using gitleaks
-      #  uses: zricethezav/gitleaks-action@master
-      #  with:
-      #    config-path: .gitleaks.toml
-      - name: Check for secrets using detect-secrets
+      - name: detect-secrets
         run: |
           git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline --exclude-files 'Pipfile\.lock$' --exclude-files '.*\.html$' --exclude-files '.*\.properties$' --exclude-files 'ci.yml' --exclude-files '\.git' --exclude-files '.*_version.py'
-        working-directory: .
+
+  detect-secrets-dogfooding:
+    name: Check secrets command dogfooding
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.python_version}}
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Determine dependencies
+        # Note
+        # The below code generates a pip requirements file from the pipenv development requirements (also obtaining the
+        # normal dependencies from setup.py).
+        # This code also forces the system to install latest tools as the ones present on the CI system may be too old
+        # for the process to go through properly.
+        # FIXME upgrade when https://github.com/pypa/pipenv/issues/4430 is actually fixed
+        run: |
+          python -m pip install --upgrade pip wheel "setuptools<81"
+          python -m pip install pipenv==${{ env.pipenv_version }}
+          echo "Locking dependencies"
+          python -m pipenv lock
+          python -m pipenv requirements > dev-requirements.txt
+      - uses: FranzDiebold/github-env-vars-action@v2
+      - name: Load Python Dependencies from cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.python_cache_ubuntu_path }}
+          key:  linux-pip-3-continuous-delivery-scripts
+      - name: Install dependencies
+        # Note
+        # As a virtual machine is already being used, pipenv
+        # is superfluous and eliminating pipenv in CI reduces overhead and reduce complexity, while retaining a single
+        # location for development dependencies.
+        run: |
+          python -m pip install -r dev-requirements.txt
+          python -m pip install "setuptools<81"
+          python -m pip list
+      - name: detect-secrets-dogfooding
+        # Note
+        # This step uses the internal command and therefore dogsfoods the repository implementation.
+        # It remains separate from `detect-secrets`, which intentionally still uses the direct
+        # `detect-secrets-hook` invocation so a bug in the wrapper command cannot reduce protection
+        # against accidentally leaking secrets.
+        run: |
+          cd-detect-secrets
 
   build-and-test:
     strategy:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 # Contributor Covenant Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 # Contribution Guide

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 # Development and Testing

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 # Known Issues

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ continuous-delivery-scripts = {editable = true, path = "."}
 allow_prereleases = false
 
 [packages]
+detect-secrets = {extras = ["gibberish"], version = "==1.5.0"}
 types-toml = "*"
 types-setuptools = "*"
 continuous-delivery-scripts = {file = ".", editable = true}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 # Automation Scripts for CI/CD

--- a/continuous_delivery_scripts/__init__.py
+++ b/continuous_delivery_scripts/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Scripts and utilities used by the CI pipeline."""

--- a/continuous_delivery_scripts/assert_news.py
+++ b/continuous_delivery_scripts/assert_news.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Checks if valid news files are created for changes in the project."""

--- a/continuous_delivery_scripts/create_news_file.py
+++ b/continuous_delivery_scripts/create_news_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Easy news files generation.

--- a/continuous_delivery_scripts/detect_secrets.py
+++ b/continuous_delivery_scripts/detect_secrets.py
@@ -1,0 +1,93 @@
+#
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Check tracked files against the project's recorded secret registry."""
+
+import argparse
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from continuous_delivery_scripts.update_secrets_registry import (
+    _determine_exclude_files,
+    _get_secrets_baseline_file,
+    _get_secrets_baseline_filename,
+)
+from continuous_delivery_scripts.utils.git_helpers import ProjectGitWrapper
+from continuous_delivery_scripts.utils.logging import log_exception, set_log_level
+
+logger = logging.getLogger(__name__)
+
+
+def _generate_detect_secrets_hook_command_list(
+    baseline_file: Path, exclude_files: List[str], tracked_files: List[str]
+) -> List[str]:
+    command = ["detect-secrets-hook", "--baseline", str(baseline_file)]
+    for exclude_file in exclude_files:
+        command.extend(["--exclude-files", exclude_file])
+    command.extend(tracked_files)
+    return command
+
+
+def _filter_tracked_files(tracked_files: List[str], project_root: Path, registry_file: Path) -> List[str]:
+    """Remove the registry file from tracked files to avoid scanning recorded accepted findings."""
+    try:
+        registry_relative_path = registry_file.relative_to(project_root).as_posix()
+    except ValueError:
+        return tracked_files
+    return [path for path in tracked_files if path != registry_relative_path]
+
+
+def detect_secrets(baseline_file: Optional[Path] = None) -> None:
+    """Check tracked files so new secrets are not introduced."""
+    git = ProjectGitWrapper()
+    project_root = Path(str(git.root))
+    resolved_baseline = _get_secrets_baseline_file(baseline_file)
+    tracked_files = _filter_tracked_files(git.list_tracked_files(), project_root, resolved_baseline)
+    if not tracked_files:
+        logger.info("No tracked files found for detect-secrets.")
+        return
+    subprocess.check_call(
+        _generate_detect_secrets_hook_command_list(resolved_baseline, _determine_exclude_files(), tracked_files),
+        cwd=str(project_root),
+    )
+
+
+def main() -> int:
+    """Script CLI."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check tracked files against the recorded secret registry so new secrets are not committed. "
+            "This uses Yelp detect-secrets (https://github.com/Yelp/detect-secrets)."
+        )
+    )
+    parser.add_argument(
+        "-r",
+        "--registry-file",
+        default=Path(_get_secrets_baseline_filename()),
+        help="Secret registry file to use.",
+        type=Path,
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Verbosity, by default errors are reported.",
+    )
+    args = parser.parse_args()
+    set_log_level(args.verbose)
+
+    try:
+        detect_secrets(args.registry_file)
+        return 0
+    except Exception as e:
+        log_exception(logger, e)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/continuous_delivery_scripts/detect_secrets.py
+++ b/continuous_delivery_scripts/detect_secrets.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Check tracked files against the project's recorded secret registry."""

--- a/continuous_delivery_scripts/generate_docs.py
+++ b/continuous_delivery_scripts/generate_docs.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Generates documentation."""

--- a/continuous_delivery_scripts/generate_news.py
+++ b/continuous_delivery_scripts/generate_news.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Handles usage of towncrier for automated changelog generation and pyautoversion for versioning."""

--- a/continuous_delivery_scripts/get_config.py
+++ b/continuous_delivery_scripts/get_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Retrieves configuration values."""

--- a/continuous_delivery_scripts/get_version.py
+++ b/continuous_delivery_scripts/get_version.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Determine the project new version."""

--- a/continuous_delivery_scripts/language_specifics.py
+++ b/continuous_delivery_scripts/language_specifics.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Language plugins Loader."""

--- a/continuous_delivery_scripts/license_files.py
+++ b/continuous_delivery_scripts/license_files.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Apply copyright and licensing to all source files present in a project.

--- a/continuous_delivery_scripts/plugins/__init__.py
+++ b/continuous_delivery_scripts/plugins/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Language specific actions."""

--- a/continuous_delivery_scripts/plugins/basic.py
+++ b/continuous_delivery_scripts/plugins/basic.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Basic plugin."""

--- a/continuous_delivery_scripts/plugins/ci.py
+++ b/continuous_delivery_scripts/plugins/ci.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for CI projects."""

--- a/continuous_delivery_scripts/plugins/docker.py
+++ b/continuous_delivery_scripts/plugins/docker.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for Docker projects."""

--- a/continuous_delivery_scripts/plugins/github_actions.py
+++ b/continuous_delivery_scripts/plugins/github_actions.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for CI projects."""

--- a/continuous_delivery_scripts/plugins/golang.py
+++ b/continuous_delivery_scripts/plugins/golang.py
@@ -203,6 +203,15 @@ class Go(BaseLanguage):
         """States whether project metadata can be retrieved."""
         return False
 
+    def get_secret_registry_exclude_files(self) -> List[str]:
+        """Gets additional detect-secrets exclude patterns for Go projects."""
+        return [
+            r".*go\.sum$",
+            r"^\.circleci[\\/].*",
+            r"^workflows/.*",
+            r"^\.github[\\/]workflows[\\/].*",
+        ]
+
     def get_current_spdx_project(self) -> Optional["SpdxProject"]:
         """Gets current SPDX description."""
         # TODO

--- a/continuous_delivery_scripts/plugins/golang.py
+++ b/continuous_delivery_scripts/plugins/golang.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for Golang projects."""

--- a/continuous_delivery_scripts/plugins/noop.py
+++ b/continuous_delivery_scripts/plugins/noop.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """No Operation plugin."""

--- a/continuous_delivery_scripts/plugins/python.py
+++ b/continuous_delivery_scripts/plugins/python.py
@@ -154,7 +154,7 @@ class Python(BaseLanguage):
 
     def get_related_language(self) -> str:
         """Gets related language."""
-        return get_language_from_file_name(__file__)
+        return str(get_language_from_file_name(__file__))
 
     def package_software(self, mode: CommitType, version: str) -> None:
         """Packages the software into a wheel."""
@@ -188,6 +188,19 @@ class Python(BaseLanguage):
         # FIXME Comment out retrieving project metadata as deprecated
         # (SetuptoolsDeprecationWarning: License classifiers are deprecated)
         return False
+
+    def get_secret_registry_exclude_files(self) -> List[str]:
+        """Gets additional detect-secrets exclude patterns for Python projects."""
+        return [
+            r".*Pipfile\.lock$",
+            r".*poetry\.lock$",
+            r".*uv\.lock$",
+            r".*pdm\.lock$",
+            r".*version\.py$",
+            r"^\.circleci[\\/].*",
+            r"^workflows/.*",
+            r"^\.github[\\/]workflows[\\/].*",
+        ]
 
     def should_include_spdx_in_package(self) -> bool:
         """States whether the SPDX documents should be included in the package."""

--- a/continuous_delivery_scripts/plugins/python.py
+++ b/continuous_delivery_scripts/plugins/python.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Plugin for Python projects."""

--- a/continuous_delivery_scripts/report_third_party_ip.py
+++ b/continuous_delivery_scripts/report_third_party_ip.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Script providing information about licensing and third party IP in order to comply with OpenChain.

--- a/continuous_delivery_scripts/spdx_report/__init__.py
+++ b/continuous_delivery_scripts/spdx_report/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Module in charge of handling SPDX documents.

--- a/continuous_delivery_scripts/spdx_report/spdx_dependency.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_dependency.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of dependency SPDX Document."""

--- a/continuous_delivery_scripts/spdx_report/spdx_document.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_document.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX Document."""

--- a/continuous_delivery_scripts/spdx_report/spdx_file.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX File."""

--- a/continuous_delivery_scripts/spdx_report/spdx_helpers.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Facilities regarding SPDX.

--- a/continuous_delivery_scripts/spdx_report/spdx_package.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_package.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX Package."""

--- a/continuous_delivery_scripts/spdx_report/spdx_project.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX report for a Python project."""

--- a/continuous_delivery_scripts/spdx_report/spdx_summary.py
+++ b/continuous_delivery_scripts/spdx_report/spdx_summary.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Summary generators."""

--- a/continuous_delivery_scripts/tag_and_release.py
+++ b/continuous_delivery_scripts/tag_and_release.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Orchestrates release process."""

--- a/continuous_delivery_scripts/update_secrets_registry.py
+++ b/continuous_delivery_scripts/update_secrets_registry.py
@@ -1,0 +1,105 @@
+#
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Record the project's accepted secret registry using detect-secrets."""
+
+import argparse
+import logging
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from continuous_delivery_scripts.language_specifics import get_language_specifics
+from continuous_delivery_scripts.utils.configuration import (
+    configuration,
+    ConfigurationVariable,
+)
+from continuous_delivery_scripts.utils.logging import log_exception, set_log_level
+
+logger = logging.getLogger(__name__)
+
+GENERIC_SECRET_REGISTRY_EXCLUDE_FILES = [
+    r".*\.html$",
+    r".*\.properties$",
+    r".*ci\.yml$",
+    r"^\.git[\\/]",
+]
+
+
+def _get_secrets_baseline_filename() -> str:
+    return str(configuration.get_value(ConfigurationVariable.SECRETS_BASELINE_FILENAME))
+
+
+def _get_secrets_baseline_file(output_file: Optional[Path] = None) -> Path:
+    project_root = Path(str(configuration.get_value(ConfigurationVariable.PROJECT_ROOT)))
+    baseline_file = output_file or Path(_get_secrets_baseline_filename())
+    return baseline_file if baseline_file.is_absolute() else project_root.joinpath(baseline_file)
+
+
+def _generate_detect_secrets_command_list(exclude_files: List[str]) -> List[str]:
+    command = ["detect-secrets", "scan", "--all-files"]
+    for exclude_file in exclude_files:
+        command.extend(["--exclude-files", exclude_file])
+    return command
+
+
+def _determine_exclude_files() -> List[str]:
+    exclude_files = list(GENERIC_SECRET_REGISTRY_EXCLUDE_FILES)
+    baseline_file_pattern = re.escape(_get_secrets_baseline_filename()).replace(r"\\", r"[\\/]")
+    exclude_files.append(rf"^{baseline_file_pattern}$")
+    exclude_files.extend(get_language_specifics().get_secret_registry_exclude_files())
+    return list(dict.fromkeys(exclude_files))
+
+
+def update_secrets_registry(output_file: Optional[Path] = None) -> Path:
+    """Record the project's accepted secret registry for detect-secrets."""
+    project_root = Path(str(configuration.get_value(ConfigurationVariable.PROJECT_ROOT)))
+    baseline_file = _get_secrets_baseline_file(output_file)
+    logger.info("Updating secrets baseline at [%s].", baseline_file)
+    baseline_contents = subprocess.check_output(
+        _generate_detect_secrets_command_list(_determine_exclude_files()),
+        cwd=str(project_root),
+        encoding="utf8",
+    )
+    baseline_file.write_text(baseline_contents, encoding="utf8")
+    return baseline_file
+
+
+def main() -> int:
+    """Script CLI."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Record the project's accepted secret registry so allowed findings are not flagged again. "
+            "This uses Yelp detect-secrets (https://github.com/Yelp/detect-secrets)."
+        )
+    )
+    parser.add_argument(
+        "-r",
+        "--registry-file",
+        default=_get_secrets_baseline_filename(),
+        help="Secret registry file to generate.",
+        type=Path,
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Verbosity, by default errors are reported.",
+    )
+    args = parser.parse_args()
+    set_log_level(args.verbose)
+
+    try:
+        update_secrets_registry(args.registry_file)
+        return 0
+    except Exception as e:
+        log_exception(logger, e)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/continuous_delivery_scripts/update_secrets_registry.py
+++ b/continuous_delivery_scripts/update_secrets_registry.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Record the project's accepted secret registry using detect-secrets."""

--- a/continuous_delivery_scripts/utils/__init__.py
+++ b/continuous_delivery_scripts/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility scripts to abstract and assist with scripts run in the CI."""

--- a/continuous_delivery_scripts/utils/aws_helpers.py
+++ b/continuous_delivery_scripts/utils/aws_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for interacting with AWS services such as S3.

--- a/continuous_delivery_scripts/utils/configuration.py
+++ b/continuous_delivery_scripts/utils/configuration.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities in charge of fetching configuration values for the ci scripts."""
@@ -205,6 +205,7 @@ class StaticConfig(GenericConfig):
     ACCEPTED_THIRD_PARTY_LICENCES = [
         "Apache-2.0",
         "BSD*",
+        "CC-BY-*",
         "JSON",
         "MIT",
         "Python-2.0",

--- a/continuous_delivery_scripts/utils/configuration.py
+++ b/continuous_delivery_scripts/utils/configuration.py
@@ -91,6 +91,8 @@ class ConfigurationVariable(enum.Enum):
     """States whether the release should be tagged with `latest`"""
     TAG_VERSION_SHORTCUTS = 36
     """States whether the release should be tagged with shortcuts i.e. major, major+minor"""
+    SECRETS_BASELINE_FILENAME = 37
+    """Filename for the detect-secrets baseline."""
 
     @staticmethod
     def choices() -> List[str]:
@@ -196,10 +198,19 @@ class StaticConfig(GenericConfig):
     AUTOGENERATE_NEWS_FILE_ON_DEPENDENCY_UPDATE = True
     TAG_LATEST = False
     TAG_VERSION_SHORTCUTS = False
+    SECRETS_BASELINE_FILENAME = ".secrets.baseline"
     DEPENDENCY_UPDATE_NEWS_MESSAGE = "Dependency upgrade: {message}"
     DEPENDENCY_UPDATE_NEWS_TYPE = NewsType.bugfix
     DEPENDENCY_UPDATE_BRANCH_PATTERN = r"^\s*[Dd]ependabot\/.+\/(?P<DEPENDENCY>.+)"
-    ACCEPTED_THIRD_PARTY_LICENCES = ["Apache-2.0", "BSD*", "JSON", "MIT", "Python-2.0", "PSF-2.0", "MPL-2.0"]
+    ACCEPTED_THIRD_PARTY_LICENCES = [
+        "Apache-2.0",
+        "BSD*",
+        "JSON",
+        "MIT",
+        "Python-2.0",
+        "PSF-2.0",
+        "MPL-2.0",
+    ]
     PACKAGES_WITH_CHECKED_LICENCE: List[str] = []
 
     def _fetch_value(self, key: str) -> Any:
@@ -277,7 +288,7 @@ class FileConfig(GenericConfig):
     @staticmethod
     def _look_for_config_file_walking_up_tree() -> Optional[str]:
         try:
-            return find_file_in_tree(FileConfig.CONFIG_FILE_NAME, top=True)
+            return str(find_file_in_tree(FileConfig.CONFIG_FILE_NAME, top=True))
         except FileNotFoundError as e:
             logger.warning(e)
         return None
@@ -287,7 +298,7 @@ class FileConfig(GenericConfig):
         if file_path and os.path.exists(file_path):
             return file_path
         try:
-            return find_file_in_tree(FileConfig.CONFIG_FILE_NAME)
+            return str(find_file_in_tree(FileConfig.CONFIG_FILE_NAME))
         except FileNotFoundError:
             return FileConfig._look_for_config_file_walking_up_tree()
 

--- a/continuous_delivery_scripts/utils/definitions.py
+++ b/continuous_delivery_scripts/utils/definitions.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Place to store generic project concepts for the ci scripts."""

--- a/continuous_delivery_scripts/utils/filesystem_helpers.py
+++ b/continuous_delivery_scripts/utils/filesystem_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers with regards to actions on the filesystem."""

--- a/continuous_delivery_scripts/utils/git_helpers.py
+++ b/continuous_delivery_scripts/utils/git_helpers.py
@@ -61,7 +61,9 @@ class GitWrapper:
         """
         try:
             git_clone = self.repo.clone_from(
-                url=self.get_remote_url(), to_path=str(path), multi_options=["--recurse-submodules"]
+                url=self.get_remote_url(),
+                to_path=str(path),
+                multi_options=["--recurse-submodules"],
             )
         except GitCommandError as e:
             logger.info("failed cloning repository: %s" % e)
@@ -235,6 +237,12 @@ class GitWrapper:
             current_branch = self._get_branch_from_abbreviation("HEAD")
         return current_branch
 
+    def list_tracked_files(self) -> List[str]:
+        """List git-tracked files relative to the repository root."""
+        tracked_files = self.repo.git.ls_files("-z")
+        tracked_files = tracked_files if isinstance(tracked_files, str) else tracked_files.decode("utf-8")
+        return [path for path in tracked_files.split("\0") if path]
+
     def _get_branch_from_advanced_feature(self) -> Any:
         if version.parse(self.git_version()) >= version.parse("2.22"):
             current_branch = self.repo.git.branch(show_current=True)
@@ -298,7 +306,10 @@ class GitWrapper:
         current_branch = self.get_current_branch()
         merge_base = self.repo.merge_base(branch, current_branch)
         self.repo.index.merge_tree(current_branch, base=merge_base)
-        self.commit(f"Merge from {str(branch)}", parent_commits=(branch.commit, current_branch.commit))
+        self.commit(
+            f"Merge from {str(branch)}",
+            parent_commits=(branch.commit, current_branch.commit),
+        )
 
     def get_remote_url(self) -> str:
         """Gets the URL of the remote repository.
@@ -416,7 +427,11 @@ class GitWrapper:
         return changes
 
     def get_changes_list(
-        self, commit1: Any, commit2: Any, change_type: Optional[str] = None, dir: Optional[str] = None
+        self,
+        commit1: Any,
+        commit2: Any,
+        change_type: Optional[str] = None,
+        dir: Optional[str] = None,
     ) -> List[str]:
         """Gets change list.
 
@@ -459,7 +474,12 @@ class GitWrapper:
         Pushes changes to the remote repository.
         Pushes also relevant annotated tags when pushing branches out.
         """
-        self.repo.git.push("--follow-tags", "--set-upstream", self._get_remote(), self.get_current_branch())
+        self.repo.git.push(
+            "--follow-tags",
+            "--set-upstream",
+            self._get_remote(),
+            self.get_current_branch(),
+        )
 
     def push_tag(self) -> None:
         """Pushes commits and tags.
@@ -797,4 +817,7 @@ class ProjectTempClone(GitTempClone):
             system will try to identify the current branch in the repository which
             will work in most cases but probably not on CI.
         """
-        super().__init__(desired_branch_name=desired_branch_name, repository_to_clone=ProjectGitWrapper())
+        super().__init__(
+            desired_branch_name=desired_branch_name,
+            repository_to_clone=ProjectGitWrapper(),
+        )

--- a/continuous_delivery_scripts/utils/git_helpers.py
+++ b/continuous_delivery_scripts/utils/git_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility script to abstract git operations for our CI scripts."""

--- a/continuous_delivery_scripts/utils/hash_helpers.py
+++ b/continuous_delivery_scripts/utils/hash_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for calculating hashes or UUID."""

--- a/continuous_delivery_scripts/utils/language_specifics_base.py
+++ b/continuous_delivery_scripts/utils/language_specifics_base.py
@@ -7,7 +7,7 @@
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Dict
+from typing import TYPE_CHECKING, Optional, Dict, List
 
 from continuous_delivery_scripts.utils.configuration import (
     configuration,
@@ -71,6 +71,10 @@ class BaseLanguage(ABC):
     def can_get_project_metadata(self) -> bool:
         """States whether project metadata can be retrieved."""
         return False
+
+    def get_secret_registry_exclude_files(self) -> List[str]:
+        """Gets additional detect-secrets exclude patterns for this plugin."""
+        return list()
 
     def should_include_spdx_in_package(self) -> bool:
         """States whether the SPDX documents should be included in the package."""

--- a/continuous_delivery_scripts/utils/language_specifics_base.py
+++ b/continuous_delivery_scripts/utils/language_specifics_base.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Base class for all Language plugins."""

--- a/continuous_delivery_scripts/utils/logging.py
+++ b/continuous_delivery_scripts/utils/logging.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for logging errors according to severity of the exception."""

--- a/continuous_delivery_scripts/utils/news_file.py
+++ b/continuous_delivery_scripts/utils/news_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers with regards to news files."""

--- a/continuous_delivery_scripts/utils/noop/__init__.py
+++ b/continuous_delivery_scripts/utils/noop/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility scripts specific to noop."""

--- a/continuous_delivery_scripts/utils/noop/package_helpers.py
+++ b/continuous_delivery_scripts/utils/noop/package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities for retrieving NoOp's package information."""

--- a/continuous_delivery_scripts/utils/package_helpers.py
+++ b/continuous_delivery_scripts/utils/package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities for retrieving Python's package information."""

--- a/continuous_delivery_scripts/utils/python/__init__.py
+++ b/continuous_delivery_scripts/utils/python/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility scripts specific to python."""

--- a/continuous_delivery_scripts/utils/python/package_helpers.py
+++ b/continuous_delivery_scripts/utils/python/package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities for retrieving Python's package information."""

--- a/continuous_delivery_scripts/utils/python/python_helpers.py
+++ b/continuous_delivery_scripts/utils/python/python_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities around python language."""

--- a/continuous_delivery_scripts/utils/string_helpers.py
+++ b/continuous_delivery_scripts/utils/string_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities regarding string handling."""

--- a/continuous_delivery_scripts/utils/third_party_licences.py
+++ b/continuous_delivery_scripts/utils/third_party_licences.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Third party licences."""

--- a/continuous_delivery_scripts/utils/versioning.py
+++ b/continuous_delivery_scripts/utils/versioning.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers with regards to versioning."""

--- a/news/20260407160538.feature
+++ b/news/20260407160538.feature
@@ -1,0 +1,1 @@
+:sparkles: add `cd-detect-secrets` to check tracked files against the recorded [detect-secrets](https://github.com/Yelp/detect-secrets) registry so new secrets are not introduced into the repository

--- a/news/20260407160539.feature
+++ b/news/20260407160539.feature
@@ -1,0 +1,1 @@
+:sparkles: add `cd-record-secrets` to record acceptable findings in the repository secret registry using [detect-secrets](https://github.com/Yelp/detect-secrets) so known safe values are not flagged repeatedly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 [ProjectConfig]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Package definition for PyPI."""

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
             f"cd-get-config={SOURCE_DIR}.get_config:main",
             f"cd-license-files={SOURCE_DIR}.license_files:main",
             f"cd-generate-spdx={SOURCE_DIR}.report_third_party_ip:main",
+            f"cd-detect-secrets={SOURCE_DIR}.detect_secrets:main",
+            f"cd-record-secrets={SOURCE_DIR}.update_secrets_registry:main",
         ]
     },
     keywords="Arm Tools CI CD Continuous Delivery Scripts Automation",
@@ -65,6 +67,7 @@ setup(
         "python-dotenv",
         "twine",
         "boto3",
+        "detect-secrets[gibberish]==1.5.0",
         "packaging",
         "licenseheaders<0.8.9",
         "spdx-tools==0.6.1",

--- a/tests/assert_news/test_news_file_validation.py
+++ b/tests/assert_news/test_news_file_validation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import mock, TestCase

--- a/tests/assert_news/test_news_files_validation.py
+++ b/tests/assert_news/test_news_files_validation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib

--- a/tests/filesystem/test_filesystem_helpers.py
+++ b/tests/filesystem/test_filesystem_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import os

--- a/tests/generate_docs/test_generate_docs_python.py
+++ b/tests/generate_docs/test_generate_docs_python.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib

--- a/tests/git_helper/test_git_helpers.py
+++ b/tests/git_helper/test_git_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/git_helper/test_git_helpers.py
+++ b/tests/git_helper/test_git_helpers.py
@@ -4,8 +4,16 @@
 #
 from unittest import TestCase
 
-from continuous_delivery_scripts.utils.configuration import configuration, ConfigurationVariable
-from continuous_delivery_scripts.utils.git_helpers import ProjectTempClone, GitTempClone, GitWrapper, ProjectGitWrapper
+from continuous_delivery_scripts.utils.configuration import (
+    configuration,
+    ConfigurationVariable,
+)
+from continuous_delivery_scripts.utils.git_helpers import (
+    ProjectTempClone,
+    GitTempClone,
+    GitWrapper,
+    ProjectGitWrapper,
+)
 from uuid import uuid4
 from pathlib import Path
 
@@ -22,6 +30,13 @@ class TestGitWrapper(TestCase):
         self.assertIsNotNone(git.uncommitted_changes)
         self.assertIsNotNone(git.get_remote_url())
 
+    def test_list_tracked_files(self):
+        """Checks tracked files can be listed from git."""
+        git = ProjectGitWrapper()
+        tracked_files = git.list_tracked_files()
+        self.assertTrue(len(tracked_files) > 0)
+        self.assertIn("setup.py", tracked_files)
+
 
 class TestGitTempClone(TestCase):
     def test_git_clone(self):
@@ -29,7 +44,10 @@ class TestGitTempClone(TestCase):
         with ProjectTempClone(desired_branch_name="main") as clone:
             self.assertTrue(isinstance(clone, GitWrapper))
             self.assertEqual("main", str(clone.get_current_branch()))
-            self.assertNotEqual(configuration.get_value(ConfigurationVariable.PROJECT_ROOT), str(clone.root))
+            self.assertNotEqual(
+                configuration.get_value(ConfigurationVariable.PROJECT_ROOT),
+                str(clone.root),
+            )
 
     def test_git_clone_independent(self):
         """Ensures the clone is independent from repository it is based on."""

--- a/tests/hash/test_hash_generation.py
+++ b/tests/hash/test_hash_generation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/licensing/test_license_files.py
+++ b/tests/licensing/test_license_files.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/licensing/test_opensource_licences.py
+++ b/tests/licensing/test_opensource_licences.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/news_file/test_create_news_file.py
+++ b/tests/news_file/test_create_news_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib

--- a/tests/packaging/test_package_helpers.py
+++ b/tests/packaging/test_package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import time

--- a/tests/python_helpers/test_python_helpers.py
+++ b/tests/python_helpers/test_python_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from continuous_delivery_scripts.utils.python.python_helpers import flatten_dictionary

--- a/tests/secrets_registry/test_detect_secrets.py
+++ b/tests/secrets_registry/test_detect_secrets.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from pathlib import Path

--- a/tests/secrets_registry/test_detect_secrets.py
+++ b/tests/secrets_registry/test_detect_secrets.py
@@ -1,0 +1,90 @@
+#
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+from pathlib import Path
+from unittest import TestCase, mock
+
+from continuous_delivery_scripts.detect_secrets import (
+    _filter_tracked_files,
+    _generate_detect_secrets_hook_command_list,
+    detect_secrets,
+)
+
+
+class TestDetectSecrets(TestCase):
+    def test_filter_tracked_files_excludes_registry(self):
+        filtered_files = _filter_tracked_files(
+            ["foo.py", ".secrets.baseline", "bar.txt"],
+            Path("/repo"),
+            Path("/repo/.secrets.baseline"),
+        )
+
+        self.assertEqual(filtered_files, ["foo.py", "bar.txt"])
+
+    def test_generate_detect_secrets_hook_command_list(self):
+        command = _generate_detect_secrets_hook_command_list(
+            Path(".secrets.baseline"), [r".*\.html$"], ["foo.py", "bar.txt"]
+        )
+
+        self.assertEqual(
+            command,
+            [
+                "detect-secrets-hook",
+                "--baseline",
+                ".secrets.baseline",
+                "--exclude-files",
+                r".*\.html$",
+                "foo.py",
+                "bar.txt",
+            ],
+        )
+
+    @mock.patch("continuous_delivery_scripts.detect_secrets.subprocess.check_call")
+    @mock.patch("continuous_delivery_scripts.detect_secrets._determine_exclude_files")
+    @mock.patch("continuous_delivery_scripts.detect_secrets.ProjectGitWrapper")
+    @mock.patch("continuous_delivery_scripts.detect_secrets._get_secrets_baseline_file")
+    def test_detect_secrets_runs_on_git_tracked_files(
+        self, get_baseline_file, ProjectGitWrapper, determine_exclude_files, check_call
+    ):
+        project_root = Path("/repo")
+        get_baseline_file.return_value = project_root.joinpath(".secrets.baseline")
+        determine_exclude_files.return_value = [r".*\.html$"]
+        ProjectGitWrapper.return_value.root = project_root
+        ProjectGitWrapper.return_value.list_tracked_files.return_value = [
+            "foo.py",
+            "bar.txt",
+            ".secrets.baseline",
+        ]
+
+        detect_secrets()
+
+        check_call.assert_called_once_with(
+            [
+                "detect-secrets-hook",
+                "--baseline",
+                str(project_root.joinpath(".secrets.baseline")),
+                "--exclude-files",
+                r".*\.html$",
+                "foo.py",
+                "bar.txt",
+            ],
+            cwd=str(project_root),
+        )
+
+    @mock.patch("continuous_delivery_scripts.detect_secrets.subprocess.check_call")
+    @mock.patch("continuous_delivery_scripts.detect_secrets._determine_exclude_files")
+    @mock.patch("continuous_delivery_scripts.detect_secrets.ProjectGitWrapper")
+    @mock.patch("continuous_delivery_scripts.detect_secrets._get_secrets_baseline_file")
+    def test_detect_secrets_skips_when_no_tracked_files(
+        self, get_baseline_file, ProjectGitWrapper, determine_exclude_files, check_call
+    ):
+        project_root = Path("/repo")
+        get_baseline_file.return_value = project_root.joinpath(".secrets.baseline")
+        determine_exclude_files.return_value = [r".*\.html$"]
+        ProjectGitWrapper.return_value.root = project_root
+        ProjectGitWrapper.return_value.list_tracked_files.return_value = []
+
+        detect_secrets()
+
+        check_call.assert_not_called()

--- a/tests/secrets_registry/test_update_secrets_registry.py
+++ b/tests/secrets_registry/test_update_secrets_registry.py
@@ -1,0 +1,101 @@
+#
+# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+from pathlib import Path
+from unittest import TestCase, mock
+
+from pyfakefs.fake_filesystem_unittest import Patcher
+
+from continuous_delivery_scripts.plugins.ci import CI
+from continuous_delivery_scripts.plugins.golang import Go
+from continuous_delivery_scripts.plugins.python import Python
+from continuous_delivery_scripts.update_secrets_registry import (
+    _get_secrets_baseline_file,
+    _determine_exclude_files,
+    _generate_detect_secrets_command_list,
+    update_secrets_registry,
+)
+
+
+class TestUpdateSecretsRegistry(TestCase):
+    @mock.patch("continuous_delivery_scripts.update_secrets_registry.get_language_specifics")
+    def test_python_exclude_files(self, get_language_specifics):
+        get_language_specifics.return_value = Python()
+
+        exclude_files = _determine_exclude_files()
+
+        self.assertIn(r".*\.html$", exclude_files)
+        self.assertIn(r".*Pipfile\.lock$", exclude_files)
+        self.assertIn(r".*version\.py$", exclude_files)
+        self.assertIn(r"^\.circleci[\\/].*", exclude_files)
+        self.assertNotIn(r".*go\.sum$", exclude_files)
+        self.assertIn(r"^workflows/.*", exclude_files)
+
+    @mock.patch("continuous_delivery_scripts.update_secrets_registry.get_language_specifics")
+    def test_go_exclude_files(self, get_language_specifics):
+        get_language_specifics.return_value = Go()
+
+        exclude_files = _determine_exclude_files()
+
+        self.assertIn(r".*go\.sum$", exclude_files)
+        self.assertIn(r"^\.circleci[\\/].*", exclude_files)
+        self.assertNotIn(r".*Pipfile\.lock$", exclude_files)
+        self.assertIn(r"^workflows/.*", exclude_files)
+
+    @mock.patch("continuous_delivery_scripts.update_secrets_registry.get_language_specifics")
+    def test_ci_does_not_exclude_workflows(self, get_language_specifics):
+        get_language_specifics.return_value = CI()
+
+        exclude_files = _determine_exclude_files()
+
+        self.assertNotIn(r"^workflows/.*", exclude_files)
+        self.assertNotIn(r"^\.github[\\/]workflows[\\/].*", exclude_files)
+
+    def test_generate_detect_secrets_command_list(self):
+        command = _generate_detect_secrets_command_list([r".*\.html$", r".*go\.sum$"])
+
+        self.assertEqual(
+            command,
+            [
+                "detect-secrets",
+                "scan",
+                "--all-files",
+                "--exclude-files",
+                r".*\.html$",
+                "--exclude-files",
+                r".*go\.sum$",
+            ],
+        )
+
+    @mock.patch("continuous_delivery_scripts.update_secrets_registry.configuration.get_value")
+    def test_get_secrets_baseline_file_from_configuration(self, get_value):
+        get_value.side_effect = ["/repo", ".secrets.baseline"]
+
+        baseline_file = _get_secrets_baseline_file()
+
+        self.assertEqual(baseline_file, Path("/repo/.secrets.baseline"))
+
+    @mock.patch("continuous_delivery_scripts.update_secrets_registry.get_language_specifics")
+    @mock.patch("continuous_delivery_scripts.update_secrets_registry.subprocess.check_output")
+    @mock.patch("continuous_delivery_scripts.update_secrets_registry.configuration.get_value")
+    def test_update_secrets_registry_writes_baseline(self, get_value, check_output, get_language_specifics):
+        get_language_specifics.return_value = Python()
+        check_output.return_value = '{"version": "1.0"}'
+
+        with Patcher() as patcher:
+            project_root = Path("/repo")
+            patcher.fs.create_dir(project_root)
+            get_value.side_effect = [
+                str(project_root),
+                str(project_root),
+                ".secrets.baseline",
+                ".secrets.baseline",
+            ]
+
+            baseline_path = update_secrets_registry()
+
+            self.assertEqual(baseline_path, project_root.joinpath(".secrets.baseline"))
+            self.assertTrue(baseline_path.exists())
+            self.assertEqual(baseline_path.read_text(encoding="utf8"), '{"version": "1.0"}')
+            check_output.assert_called_once()

--- a/tests/secrets_registry/test_update_secrets_registry.py
+++ b/tests/secrets_registry/test_update_secrets_registry.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from pathlib import Path

--- a/tests/spdx/test_spdx_file.py
+++ b/tests/spdx/test_spdx_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/spdx/test_spdx_helper.py
+++ b/tests/spdx/test_spdx_helper.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/spdx/test_spdx_project.py
+++ b/tests/spdx/test_spdx_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/string_helpers/test_string_helpers.py
+++ b/tests/string_helpers/test_string_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/tag_and_release/test_update_documentation_python.py
+++ b/tests/tag_and_release/test_update_documentation_python.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Tests for  documentation update functions."""

--- a/tests/versioning/test_versioning.py
+++ b/tests/versioning/test_versioning.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
+# Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest


### PR DESCRIPTION
<!--
Copyright (C) 2020-2025 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

 added two wrappers around [detect-secrets](https://github.com/Yelp/detect-secrets) to ease baseline generation based on project type and programming language



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
