### PR TITLE
:bug: Ensure that if a fetch fails it retries with authentication in the same way as clone

### DIFF
--- a/continuous_delivery_scripts/utils/git_helpers.py
+++ b/continuous_delivery_scripts/utils/git_helpers.py
@@ -200,7 +200,7 @@ class GitWrapper:
             self.repo.git.fetch(all=True, tags=True, force=True)
         except GitCommandError as e:
             logger.info("failed fetching repository: %s" % e)
-            logger.info("trying with authentication")
+            logger.info("Retrying a different way")
             self.set_remote_url(self._git_url_ssh_to_https(self.get_remote_url()))
             self.repo.git.fetch(all=True, tags=True, force=True)
 

--- a/continuous_delivery_scripts/utils/git_helpers.py
+++ b/continuous_delivery_scripts/utils/git_helpers.py
@@ -196,7 +196,13 @@ class GitWrapper:
 
     def fetch(self) -> None:
         """Fetches latest changes."""
-        self.repo.git.fetch(all=True, tags=True, force=True)
+        try:
+            self.repo.git.fetch(all=True, tags=True, force=True)
+        except GitCommandError as e:
+            logger.info("failed fetching repository: %s" % e)
+            logger.info("trying with authentication")
+            self.set_remote_url(self._git_url_ssh_to_https(self.get_remote_url()))
+            self.repo.git.fetch(all=True, tags=True, force=True)
 
     def get_branch(self, branch_name: str) -> Any:
         """Gets a specific local branch.

--- a/news/20260601135433.bugfix
+++ b/news/20260601135433.bugfix
@@ -1,0 +1,1 @@
+:bug: Ensure that if a fetch fails it retries with authentication in the same way as clone

--- a/tests/git_helper/test_git_helpers.py
+++ b/tests/git_helper/test_git_helpers.py
@@ -61,9 +61,7 @@ class TestGitWrapper(TestCase):
         git.fetch()
 
         self.assertEqual(2, repo.git.fetch.call_count)
-        set_remote_url.assert_called_once_with(
-            "https://test-token:x-oauth-basic@github.com/example/repository.git"
-        )
+        set_remote_url.assert_called_once_with("https://test-token:x-oauth-basic@github.com/example/repository.git")
 
 
 class TestGitTempClone(TestCase):

--- a/tests/git_helper/test_git_helpers.py
+++ b/tests/git_helper/test_git_helpers.py
@@ -2,7 +2,9 @@
 # Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-from unittest import TestCase
+from unittest import TestCase, mock
+
+from git import GitCommandError
 
 from continuous_delivery_scripts.utils.configuration import (
     configuration,
@@ -36,6 +38,32 @@ class TestGitWrapper(TestCase):
         tracked_files = git.list_tracked_files()
         self.assertTrue(len(tracked_files) > 0)
         self.assertIn("setup.py", tracked_files)
+
+    @mock.patch.object(GitWrapper, "set_remote_url")
+    @mock.patch.object(
+        GitWrapper,
+        "_git_url_ssh_to_https",
+        return_value="https://test-token:x-oauth-basic@github.com/example/repository.git",
+    )
+    @mock.patch.object(
+        GitWrapper,
+        "get_remote_url",
+        return_value="https://github.com/example/repository.git",
+    )
+    def test_fetch_retries_with_authentication(self, _get_remote_url, _git_url_ssh_to_https, set_remote_url):
+        """Ensures fetch retries with authentication when needed."""
+        repo = mock.Mock(spec_set=["git"])
+        repo.git = mock.Mock(spec_set=["fetch"])
+        repo.git.fetch.side_effect = [GitCommandError("fetch", 128, stderr="fatal"), None]
+
+        git = GitWrapper(path=Path("."), repo=repo)
+
+        git.fetch()
+
+        self.assertEqual(2, repo.git.fetch.call_count)
+        set_remote_url.assert_called_once_with(
+            "https://test-token:x-oauth-basic@github.com/example/repository.git"
+        )
 
 
 class TestGitTempClone(TestCase):


### PR DESCRIPTION
<!--
Copyright (C) 2020-2026 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Problem:

- `cd-assert-news` creates a temporary clone of the repo
- that clone later does a git fetch
- the fetch used the normal remote URL without authentication
- in a private repo, that failed with GitHub credential errors

Fix:

- it tries a normal fetch first
- if that fails, it retries using the authenticated GitHub URL built from `GIT_TOKEN`

This is the same way htat `clone()` works.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
